### PR TITLE
IndexedDBでのファイル保存に関する説明を追加

### DIFF
--- a/src/pages/RootPage.tsx
+++ b/src/pages/RootPage.tsx
@@ -57,9 +57,13 @@ export function RootPage() {
         >
           アップロード
         </button>
-        <div className="text-info text-sm mt-2">
-          <p>アップロードされたファイルは、ブラウザ内のIndexedDBに安全に保存されます。</p>
-          <p>データはお使いのブラウザ内にのみ保存され、外部に送信されることはありません。</p>
+        <div className="text-info mt-2 text-sm">
+          <p>
+            アップロードされたファイルは、ブラウザ内のIndexedDBに安全に保存されます。
+          </p>
+          <p>
+            データはお使いのブラウザ内にのみ保存され、外部に送信されることはありません。
+          </p>
         </div>
       </div>
 


### PR DESCRIPTION
close #31 

ファイルアップロード機能の説明として、以下を追加:
- ファイルがブラウザ内のIndexedDBに保存されることの説明
- データがローカルにのみ保存され外部に送信されないことを明記
- テキストカラーをtext-infoに設定し情報として目立つように表示

🤖 Generated with [Claude Code](https://claude.ai/code)