### PR TITLE
タグ機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "payview",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tailwindcss/vite": "4.1.12",
         "@tanstack/react-router": "1.131.17",
         "@tanstack/react-router-devtools": "1.131.17",
@@ -524,6 +527,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -5696,7 +5752,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tailwindcss/vite": "4.1.12",
     "@tanstack/react-router": "1.131.17",
     "@tanstack/react-router-devtools": "1.131.17",

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -12,13 +12,34 @@ interface PaymentFile {
   payments: Payment[];
 }
 
+interface Tag {
+  id: string;
+  name: string;
+  order: number;
+}
+
+interface TagRule {
+  id: string;
+  tagId: string;
+  pattern: string;
+  order: number;
+}
+
 const db = new Dexie("PaymentFileDatabase") as Dexie & {
   paymentFiles: EntityTable<PaymentFile, "fileName">;
+  tags: EntityTable<Tag, "id">;
+  tagRules: EntityTable<TagRule, "id">;
 };
 
 db.version(1).stores({
   paymentFiles: "fileName",
 });
 
-export type { PaymentFile };
+db.version(2).stores({
+  paymentFiles: "fileName",
+  tags: "id, order",
+  tagRules: "id, tagId, order",
+});
+
+export type { PaymentFile, Tag, TagRule };
 export { db };

--- a/src/data/tags/addTag.ts
+++ b/src/data/tags/addTag.ts
@@ -1,0 +1,32 @@
+import { ResultAsync } from "neverthrow";
+import { db } from "../db";
+
+type Input = { name: string };
+type Output = string;
+
+export function addTag(input: Input): ResultAsync<Output, AddTagError> {
+  return ResultAsync.fromPromise(
+    (async () => {
+      const id = crypto.randomUUID();
+      const maxOrder = await db.tags.orderBy("order").last();
+      const order = maxOrder ? maxOrder.order + 1 : 0;
+
+      await db.tags.add({
+        id,
+        name: input.name,
+        order,
+      });
+
+      return id;
+    })(),
+    (err) => new AddTagError("タグの追加に失敗しました。", { cause: err }),
+  );
+}
+
+export class AddTagError extends Error {
+  override readonly name = "AddTagError" as const;
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}

--- a/src/data/tags/addTagRule.ts
+++ b/src/data/tags/addTagRule.ts
@@ -1,0 +1,38 @@
+import { ResultAsync } from "neverthrow";
+import { db } from "../db";
+
+type Input = { tagId: string; pattern: string };
+type Output = string;
+
+export function addTagRule(input: Input): ResultAsync<Output, AddTagRuleError> {
+  return ResultAsync.fromPromise(
+    (async () => {
+      const id = crypto.randomUUID();
+      const maxOrder = await db.tagRules
+        .where("tagId")
+        .equals(input.tagId)
+        .sortBy("order")
+        .then((rules) => rules[rules.length - 1]);
+      const order = maxOrder ? maxOrder.order + 1 : 0;
+
+      await db.tagRules.add({
+        id,
+        tagId: input.tagId,
+        pattern: input.pattern,
+        order,
+      });
+
+      return id;
+    })(),
+    (err) =>
+      new AddTagRuleError("ルールの追加に失敗しました。", { cause: err }),
+  );
+}
+
+export class AddTagRuleError extends Error {
+  override readonly name = "AddTagRuleError" as const;
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}

--- a/src/data/tags/deleteTag.ts
+++ b/src/data/tags/deleteTag.ts
@@ -1,0 +1,26 @@
+import { ResultAsync } from "neverthrow";
+import { db } from "../db";
+
+type Input = { id: string };
+type Output = undefined;
+
+export function deleteTag(input: Input): ResultAsync<Output, DeleteTagError> {
+  return ResultAsync.fromPromise(
+    (async () => {
+      await db.transaction("rw", [db.tags, db.tagRules], async () => {
+        await db.tagRules.where("tagId").equals(input.id).delete();
+        await db.tags.delete(input.id);
+      });
+      return undefined;
+    })(),
+    (err) => new DeleteTagError("タグの削除に失敗しました。", { cause: err }),
+  );
+}
+
+export class DeleteTagError extends Error {
+  override readonly name = "DeleteTagError" as const;
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}

--- a/src/data/tags/deleteTagRule.ts
+++ b/src/data/tags/deleteTagRule.ts
@@ -1,0 +1,26 @@
+import { ResultAsync } from "neverthrow";
+import { db } from "../db";
+
+type Input = { id: string };
+type Output = undefined;
+
+export function deleteTagRule(
+  input: Input,
+): ResultAsync<Output, DeleteTagRuleError> {
+  return ResultAsync.fromPromise(
+    (async () => {
+      await db.tagRules.delete(input.id);
+      return undefined;
+    })(),
+    (err) =>
+      new DeleteTagRuleError("ルールの削除に失敗しました。", { cause: err }),
+  );
+}
+
+export class DeleteTagRuleError extends Error {
+  override readonly name = "DeleteTagRuleError" as const;
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}

--- a/src/data/tags/reorderTagRules.ts
+++ b/src/data/tags/reorderTagRules.ts
@@ -1,0 +1,32 @@
+import { ResultAsync } from "neverthrow";
+import { db } from "../db";
+
+type Input = { ruleIds: string[] };
+type Output = undefined;
+
+export function reorderTagRules(
+  input: Input,
+): ResultAsync<Output, ReorderTagRulesError> {
+  return ResultAsync.fromPromise(
+    (async () => {
+      await db.transaction("rw", db.tagRules, async () => {
+        for (let i = 0; i < input.ruleIds.length; i++) {
+          await db.tagRules.update(input.ruleIds[i], { order: i });
+        }
+      });
+      return undefined;
+    })(),
+    (err) =>
+      new ReorderTagRulesError("ルールの並び替えに失敗しました。", {
+        cause: err,
+      }),
+  );
+}
+
+export class ReorderTagRulesError extends Error {
+  override readonly name = "ReorderTagRulesError" as const;
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}

--- a/src/data/tags/reorderTags.ts
+++ b/src/data/tags/reorderTags.ts
@@ -1,0 +1,30 @@
+import { ResultAsync } from "neverthrow";
+import { db } from "../db";
+
+type Input = { tagIds: string[] };
+type Output = undefined;
+
+export function reorderTags(
+  input: Input,
+): ResultAsync<Output, ReorderTagsError> {
+  return ResultAsync.fromPromise(
+    (async () => {
+      await db.transaction("rw", db.tags, async () => {
+        for (let i = 0; i < input.tagIds.length; i++) {
+          await db.tags.update(input.tagIds[i], { order: i });
+        }
+      });
+      return undefined;
+    })(),
+    (err) =>
+      new ReorderTagsError("タグの並び替えに失敗しました。", { cause: err }),
+  );
+}
+
+export class ReorderTagsError extends Error {
+  override readonly name = "ReorderTagsError" as const;
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}

--- a/src/data/tags/updateTag.ts
+++ b/src/data/tags/updateTag.ts
@@ -1,0 +1,23 @@
+import { ResultAsync } from "neverthrow";
+import { db } from "../db";
+
+type Input = { id: string; name: string };
+type Output = undefined;
+
+export function updateTag(input: Input): ResultAsync<Output, UpdateTagError> {
+  return ResultAsync.fromPromise(
+    (async () => {
+      await db.tags.update(input.id, { name: input.name });
+      return undefined;
+    })(),
+    (err) => new UpdateTagError("タグの更新に失敗しました。", { cause: err }),
+  );
+}
+
+export class UpdateTagError extends Error {
+  override readonly name = "UpdateTagError" as const;
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}

--- a/src/data/tags/updateTagRule.ts
+++ b/src/data/tags/updateTagRule.ts
@@ -1,0 +1,26 @@
+import { ResultAsync } from "neverthrow";
+import { db } from "../db";
+
+type Input = { id: string; pattern: string };
+type Output = undefined;
+
+export function updateTagRule(
+  input: Input,
+): ResultAsync<Output, UpdateTagRuleError> {
+  return ResultAsync.fromPromise(
+    (async () => {
+      await db.tagRules.update(input.id, { pattern: input.pattern });
+      return undefined;
+    })(),
+    (err) =>
+      new UpdateTagRuleError("ルールの更新に失敗しました。", { cause: err }),
+  );
+}
+
+export class UpdateTagRuleError extends Error {
+  override readonly name = "UpdateTagRuleError" as const;
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}

--- a/src/data/tags/useAllTagRules.ts
+++ b/src/data/tags/useAllTagRules.ts
@@ -1,0 +1,32 @@
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, type Tag, type TagRule } from "../db";
+
+type TagWithRules = Tag & {
+  rules: TagRule[];
+};
+
+type UseAllTagRulesResult =
+  | { status: "loading" }
+  | { status: "completed"; tagsWithRules: TagWithRules[] };
+
+export function useAllTagRules(): UseAllTagRulesResult {
+  const result = useLiveQuery(async () => {
+    const tags = await db.tags.orderBy("order").toArray();
+    const allRules = await db.tagRules.toArray();
+
+    const tagsWithRules: TagWithRules[] = tags.map((tag) => ({
+      ...tag,
+      rules: allRules
+        .filter((rule) => rule.tagId === tag.id)
+        .sort((a, b) => a.order - b.order),
+    }));
+
+    return tagsWithRules;
+  });
+
+  if (!result) {
+    return { status: "loading" as const };
+  }
+
+  return { status: "completed" as const, tagsWithRules: result };
+}

--- a/src/data/tags/useTagRules.ts
+++ b/src/data/tags/useTagRules.ts
@@ -1,0 +1,23 @@
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, type TagRule } from "../db";
+
+type Props = {
+  tagId: string;
+};
+
+type UseTagRulesResult =
+  | { status: "loading" }
+  | { status: "completed"; rules: TagRule[] };
+
+export function useTagRules({ tagId }: Props): UseTagRulesResult {
+  const rules = useLiveQuery(
+    () => db.tagRules.where("tagId").equals(tagId).sortBy("order"),
+    [tagId],
+  );
+
+  if (!rules) {
+    return { status: "loading" as const };
+  }
+
+  return { status: "completed" as const, rules };
+}

--- a/src/data/tags/useTags.ts
+++ b/src/data/tags/useTags.ts
@@ -1,0 +1,16 @@
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, type Tag } from "../db";
+
+type UseTagsResult =
+  | { status: "loading" }
+  | { status: "completed"; tags: Tag[] };
+
+export function useTags(): UseTagsResult {
+  const tags = useLiveQuery(() => db.tags.orderBy("order").toArray());
+
+  if (!tags) {
+    return { status: "loading" as const };
+  }
+
+  return { status: "completed" as const, tags };
+}

--- a/src/data/usePaymentsByTag.ts
+++ b/src/data/usePaymentsByTag.ts
@@ -1,0 +1,98 @@
+import { useMemo } from "react";
+import { usePayments } from "./usePayments";
+import { useAllTagRules } from "./tags/useAllTagRules";
+
+type Props = {
+  fileName: string;
+};
+
+type TagInfo = {
+  id: string;
+  name: string;
+} | null;
+
+type TagBreakdownItem = {
+  tag: TagInfo;
+  total: number;
+  count: number;
+  name?: string;
+};
+
+type UsePaymentsByTagResult =
+  | { status: "loading" }
+  | { status: "completed"; breakdown: TagBreakdownItem[] };
+
+export function usePaymentsByTag({ fileName }: Props): UsePaymentsByTagResult {
+  const payments = usePayments({ fileName });
+  const tagsResult = useAllTagRules();
+
+  const breakdown = useMemo(() => {
+    if (payments.status === "loading" || tagsResult.status === "loading") {
+      return { status: "loading" as const };
+    }
+
+    const { tagsWithRules } = tagsResult;
+
+    const findTagForPayment = (paymentName: string): TagInfo => {
+      for (const tag of tagsWithRules) {
+        for (const rule of tag.rules) {
+          if (paymentName.includes(rule.pattern)) {
+            return { id: tag.id, name: tag.name };
+          }
+        }
+      }
+      return null;
+    };
+
+    const tagTotals = new Map<
+      string,
+      { tag: TagInfo; total: number; count: number }
+    >();
+    const untaggedItems: { name: string; total: number }[] = [];
+    const untaggedTotals = new Map<string, number>();
+
+    for (const payment of payments.payments) {
+      const tag = findTagForPayment(payment.name);
+
+      if (tag) {
+        const key = tag.id;
+        const existing = tagTotals.get(key);
+        if (existing) {
+          existing.total += payment.price;
+          existing.count += 1;
+        } else {
+          tagTotals.set(key, { tag, total: payment.price, count: 1 });
+        }
+      } else {
+        const existing = untaggedTotals.get(payment.name);
+        if (existing !== undefined) {
+          untaggedTotals.set(payment.name, existing + payment.price);
+        } else {
+          untaggedTotals.set(payment.name, payment.price);
+        }
+      }
+    }
+
+    for (const [name, total] of untaggedTotals) {
+      untaggedItems.push({ name, total });
+    }
+
+    const taggedBreakdown = Array.from(tagTotals.values());
+    taggedBreakdown.sort((a, b) => b.total - a.total);
+
+    untaggedItems.sort((a, b) => b.total - a.total);
+    const untaggedBreakdown: TagBreakdownItem[] = untaggedItems.map((item) => ({
+      tag: null,
+      total: item.total,
+      count: 1,
+      name: item.name,
+    }));
+
+    return {
+      status: "completed" as const,
+      breakdown: [...taggedBreakdown, ...untaggedBreakdown],
+    };
+  }, [payments, tagsResult]);
+
+  return breakdown;
+}

--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -2,10 +2,11 @@ import { Tabs } from "./components/Tabs";
 import { Activity } from "react";
 import { PaymentBreakdownView } from "./components/PaymentBreakdownView/PaymentBreakdownView";
 import { PaymentView } from "./components/PaymentView/PaymentView";
+import { PaymentTagView } from "./components/PaymentTagView/PaymentTagView";
 
 type Props = {
   fileName: string;
-  activeTab: "payments" | "breakdown";
+  activeTab: "payments" | "breakdown" | "tags";
 };
 
 export function DetailPage({ fileName, activeTab }: Props) {
@@ -19,6 +20,10 @@ export function DetailPage({ fileName, activeTab }: Props) {
 
       <Activity mode={activeTab === "breakdown" ? "visible" : "hidden"}>
         <PaymentBreakdownView fileName={fileName} />
+      </Activity>
+
+      <Activity mode={activeTab === "tags" ? "visible" : "hidden"}>
+        <PaymentTagView fileName={fileName} />
       </Activity>
     </div>
   );

--- a/src/pages/DetailPage/components/PaymentTagView/PaymentTagView.tsx
+++ b/src/pages/DetailPage/components/PaymentTagView/PaymentTagView.tsx
@@ -1,0 +1,104 @@
+import { Link } from "@tanstack/react-router";
+import { usePaymentsByTag } from "../../../../data/usePaymentsByTag";
+import { PayviewTagBarChart } from "./PayviewTagBarChart";
+
+type Props = {
+  fileName: string;
+};
+
+export function PaymentTagView({ fileName }: Props) {
+  const result = usePaymentsByTag({ fileName });
+
+  if (result.status === "loading") {
+    return (
+      <div className="mx-auto w-max">
+        <span className="loading loading-spinner loading-xl"></span>
+      </div>
+    );
+  }
+
+  const { breakdown } = result;
+  const taggedItems = breakdown.filter((item) => item.tag !== null);
+  const untaggedItems = breakdown.filter((item) => item.tag === null);
+
+  const chartData = taggedItems.slice(0, 20).map((item) => ({
+    name: item.tag?.name || "",
+    value: item.total,
+  }));
+
+  const hasNoTags = taggedItems.length === 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {hasNoTags ? (
+        <div className="bg-base-200 rounded-box p-6 text-center">
+          <p className="text-base-content/60 mb-2">タグが設定されていません</p>
+          <Link to="/settings" className="btn btn-primary btn-sm">
+            タグを設定する
+          </Link>
+        </div>
+      ) : (
+        <>
+          <div>
+            <h3 className="text-secondary-content mb-2 text-lg">
+              タグ別集計（上位20件）
+            </h3>
+            <PayviewTagBarChart data={chartData} />
+          </div>
+
+          <div>
+            <h3 className="text-secondary-content mb-2 text-lg">タグ別内訳</h3>
+            <div className="overflow-x-auto">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>タグ</th>
+                    <th>件数</th>
+                    <th>金額</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {taggedItems.map((item) => (
+                    <tr key={item.tag?.id}>
+                      <td>
+                        <span className="badge badge-primary">
+                          {item.tag?.name}
+                        </span>
+                      </td>
+                      <td>{item.count} 件</td>
+                      <td>{item.total.toLocaleString()} 円</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+
+      {untaggedItems.length > 0 && (
+        <div>
+          <h3 className="text-secondary-content mb-2 text-lg">未分類</h3>
+          <div className="overflow-x-auto">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>項目</th>
+                  <th>金額</th>
+                </tr>
+              </thead>
+              <tbody>
+                {untaggedItems.map((item, index) => (
+                  <tr key={index}>
+                    <td>{item.name}</td>
+                    <td>{item.total.toLocaleString()} 円</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/DetailPage/components/PaymentTagView/PayviewTagBarChart.tsx
+++ b/src/pages/DetailPage/components/PaymentTagView/PayviewTagBarChart.tsx
@@ -1,0 +1,39 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Cell,
+  ResponsiveContainer,
+} from "recharts";
+
+type Props = {
+  data: { name: string; value: number }[];
+};
+
+const COLORS = ["#8B5CF6", "#06B6D4", "#10B981", "#F59E0B", "#EF4444"];
+
+export function PayviewTagBarChart({ data }: Props) {
+  return (
+    <div className="max-w-full">
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={data}>
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip
+            formatter={(value: number) => [
+              `${value.toLocaleString()} 円`,
+              "金額",
+            ]}
+          />
+          <Bar dataKey="value">
+            {data.map((item, index) => (
+              <Cell key={item.name} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/pages/DetailPage/components/Tabs.tsx
+++ b/src/pages/DetailPage/components/Tabs.tsx
@@ -4,7 +4,7 @@ import { TotalAmount } from "./TotalAmount";
 
 type Props = {
   fileName: string;
-  activeTab: "payments" | "breakdown";
+  activeTab: "payments" | "breakdown" | "tags";
 };
 
 export function Tabs({ fileName, activeTab }: Props) {
@@ -33,6 +33,16 @@ export function Tabs({ fileName, activeTab }: Props) {
           search={{ tab: "breakdown" }}
         >
           内訳
+        </Link>
+
+        <Link
+          role="tab"
+          className={clsx("tab", activeTab === "tags" && "tab-active")}
+          to="/payments/$fileName"
+          params={{ fileName }}
+          search={{ tab: "tags" }}
+        >
+          タグ別
         </Link>
       </div>
       <Outlet />

--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -1,0 +1,41 @@
+import { Link } from "@tanstack/react-router";
+import { useTags } from "../../data/tags/useTags";
+import { TagList } from "./components/TagList";
+import { AddTagForm } from "./components/AddTagForm";
+
+export function SettingsPage() {
+  const tagsResult = useTags();
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-4">
+        <Link to="/" className="btn btn-ghost btn-sm">
+          ← 戻る
+        </Link>
+        <h1 className="text-primary-content text-xl">タグ設定</h1>
+      </div>
+
+      <div className="text-info text-sm">
+        <p>タグを設定すると、項目名に含まれる文言でグループ分けができます。</p>
+        <p>
+          複数のルールがマッチした場合は、リストの上にあるタグが優先されます。
+        </p>
+      </div>
+
+      <AddTagForm />
+
+      {tagsResult.status === "loading" ? (
+        <div className="flex justify-center py-8">
+          <span className="loading loading-spinner loading-lg" />
+        </div>
+      ) : tagsResult.tags.length === 0 ? (
+        <div className="bg-base-200 rounded-box text-base-content/60 w-full p-8 text-center">
+          <p>タグがまだありません</p>
+          <p className="mt-2 text-sm">上のフォームからタグを追加してください</p>
+        </div>
+      ) : (
+        <TagList tags={tagsResult.tags} />
+      )}
+    </div>
+  );
+}

--- a/src/pages/SettingsPage/components/AddTagForm.tsx
+++ b/src/pages/SettingsPage/components/AddTagForm.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { addTag } from "../../../data/tags/addTag";
+
+export function AddTagForm() {
+  const [name, setName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!name.trim()) return;
+
+    setIsSubmitting(true);
+    const result = await addTag({ name: name.trim() });
+    setIsSubmitting(false);
+
+    if (result.isErr()) {
+      alert(result.error.message);
+      return;
+    }
+
+    setName("");
+  };
+
+  return (
+    <div className="flex gap-2">
+      <input
+        type="text"
+        placeholder="新しいタグ名"
+        className="input input-bordered flex-1"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            void handleSubmit();
+          }
+        }}
+      />
+      <button
+        type="button"
+        className="btn btn-primary"
+        onClick={() => void handleSubmit()}
+        disabled={!name.trim() || isSubmitting}
+      >
+        {isSubmitting ? (
+          <span className="loading loading-spinner loading-sm" />
+        ) : (
+          "追加"
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/pages/SettingsPage/components/AddTagRuleForm.tsx
+++ b/src/pages/SettingsPage/components/AddTagRuleForm.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { addTagRule } from "../../../data/tags/addTagRule";
+
+type Props = {
+  tagId: string;
+};
+
+export function AddTagRuleForm({ tagId }: Props) {
+  const [pattern, setPattern] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!pattern.trim()) return;
+
+    setIsSubmitting(true);
+    const result = await addTagRule({ tagId, pattern: pattern.trim() });
+    setIsSubmitting(false);
+
+    if (result.isErr()) {
+      alert(result.error.message);
+      return;
+    }
+
+    setPattern("");
+  };
+
+  return (
+    <div className="flex gap-2">
+      <input
+        type="text"
+        placeholder="マッチさせる文言を入力"
+        className="input input-bordered input-sm flex-1"
+        value={pattern}
+        onChange={(e) => setPattern(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            void handleSubmit();
+          }
+        }}
+      />
+      <button
+        type="button"
+        className="btn btn-primary btn-sm"
+        onClick={() => void handleSubmit()}
+        disabled={!pattern.trim() || isSubmitting}
+      >
+        {isSubmitting ? (
+          <span className="loading loading-spinner loading-xs" />
+        ) : (
+          "ルールを追加"
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/pages/SettingsPage/components/TagItem.tsx
+++ b/src/pages/SettingsPage/components/TagItem.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { type Tag } from "../../../data/db";
+import { updateTag } from "../../../data/tags/updateTag";
+import { deleteTag } from "../../../data/tags/deleteTag";
+import { useTagRules } from "../../../data/tags/useTagRules";
+import { TagRuleList } from "./TagRuleList";
+import { AddTagRuleForm } from "./AddTagRuleForm";
+
+type Props = {
+  tag: Tag;
+};
+
+export function TagItem({ tag }: Props) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(tag.name);
+  const rulesResult = useTagRules({ tagId: tag.id });
+
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: tag.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const handleUpdate = async () => {
+    if (!editName.trim()) return;
+
+    const result = await updateTag({ id: tag.id, name: editName.trim() });
+    if (result.isErr()) {
+      alert(result.error.message);
+      return;
+    }
+    setIsEditing(false);
+  };
+
+  const handleDelete = async () => {
+    if (
+      !confirm(
+        `タグ「${tag.name}」を削除しますか？関連するルールも削除されます。`,
+      )
+    ) {
+      return;
+    }
+
+    const result = await deleteTag({ id: tag.id });
+    if (result.isErr()) {
+      alert(result.error.message);
+    }
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="bg-base-200 rounded-box overflow-hidden"
+    >
+      <div className="flex items-center gap-2 p-3">
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm cursor-grab px-1"
+          {...attributes}
+          {...listeners}
+        >
+          ⋮⋮
+        </button>
+
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm px-2"
+          onClick={() => setIsExpanded(!isExpanded)}
+        >
+          {isExpanded ? "▼" : "▶"}
+        </button>
+
+        {isEditing ? (
+          <div className="flex flex-1 items-center gap-2">
+            <input
+              type="text"
+              className="input input-bordered input-sm flex-1"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleUpdate();
+                if (e.key === "Escape") {
+                  setIsEditing(false);
+                  setEditName(tag.name);
+                }
+              }}
+              autoFocus
+            />
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={() => void handleUpdate()}
+            >
+              保存
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={() => {
+                setIsEditing(false);
+                setEditName(tag.name);
+              }}
+            >
+              キャンセル
+            </button>
+          </div>
+        ) : (
+          <>
+            <span className="flex-1 font-medium">{tag.name}</span>
+            <span className="text-base-content/60 text-sm">
+              {rulesResult.status === "completed"
+                ? `${rulesResult.rules.length} ルール`
+                : "..."}
+            </span>
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={() => setIsEditing(true)}
+            >
+              編集
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm text-error"
+              onClick={() => void handleDelete()}
+            >
+              削除
+            </button>
+          </>
+        )}
+      </div>
+
+      {isExpanded && (
+        <div className="bg-base-300 border-base-content/10 border-t p-3">
+          <div className="mb-3">
+            <h4 className="text-base-content/80 mb-2 text-sm font-medium">
+              マッチングルール
+            </h4>
+            {rulesResult.status === "loading" ? (
+              <span className="loading loading-spinner loading-sm" />
+            ) : rulesResult.rules.length === 0 ? (
+              <p className="text-base-content/60 text-sm">ルールがありません</p>
+            ) : (
+              <TagRuleList rules={rulesResult.rules} />
+            )}
+          </div>
+          <AddTagRuleForm tagId={tag.id} />
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/pages/SettingsPage/components/TagList.tsx
+++ b/src/pages/SettingsPage/components/TagList.tsx
@@ -1,0 +1,66 @@
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { type Tag } from "../../../data/db";
+import { reorderTags } from "../../../data/tags/reorderTags";
+import { TagItem } from "./TagItem";
+
+type Props = {
+  tags: Tag[];
+};
+
+export function TagList({ tags }: Props) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    const oldIndex = tags.findIndex((tag) => tag.id === active.id);
+    const newIndex = tags.findIndex((tag) => tag.id === over.id);
+
+    const newOrder = [...tags];
+    const [removed] = newOrder.splice(oldIndex, 1);
+    newOrder.splice(newIndex, 0, removed);
+
+    await reorderTags({ tagIds: newOrder.map((tag) => tag.id) });
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={(event) => void handleDragEnd(event)}
+    >
+      <SortableContext
+        items={tags.map((t) => t.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <ul className="flex flex-col gap-2">
+          {tags.map((tag) => (
+            <TagItem key={tag.id} tag={tag} />
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/src/pages/SettingsPage/components/TagRuleItem.tsx
+++ b/src/pages/SettingsPage/components/TagRuleItem.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { type TagRule } from "../../../data/db";
+import { updateTagRule } from "../../../data/tags/updateTagRule";
+import { deleteTagRule } from "../../../data/tags/deleteTagRule";
+
+type Props = {
+  rule: TagRule;
+};
+
+export function TagRuleItem({ rule }: Props) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editPattern, setEditPattern] = useState(rule.pattern);
+
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: rule.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const handleUpdate = async () => {
+    if (!editPattern.trim()) return;
+
+    const result = await updateTagRule({
+      id: rule.id,
+      pattern: editPattern.trim(),
+    });
+    if (result.isErr()) {
+      alert(result.error.message);
+      return;
+    }
+    setIsEditing(false);
+  };
+
+  const handleDelete = async () => {
+    if (!confirm(`ルール「${rule.pattern}」を削除しますか？`)) {
+      return;
+    }
+
+    const result = await deleteTagRule({ id: rule.id });
+    if (result.isErr()) {
+      alert(result.error.message);
+    }
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="bg-base-100 flex items-center gap-2 rounded p-2"
+    >
+      <button
+        type="button"
+        className="btn btn-ghost btn-xs cursor-grab px-1"
+        {...attributes}
+        {...listeners}
+      >
+        ⋮⋮
+      </button>
+
+      {isEditing ? (
+        <div className="flex flex-1 items-center gap-2">
+          <input
+            type="text"
+            className="input input-bordered input-xs flex-1"
+            value={editPattern}
+            onChange={(e) => setEditPattern(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleUpdate();
+              if (e.key === "Escape") {
+                setIsEditing(false);
+                setEditPattern(rule.pattern);
+              }
+            }}
+            autoFocus
+          />
+          <button
+            type="button"
+            className="btn btn-primary btn-xs"
+            onClick={() => void handleUpdate()}
+          >
+            保存
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs"
+            onClick={() => {
+              setIsEditing(false);
+              setEditPattern(rule.pattern);
+            }}
+          >
+            キャンセル
+          </button>
+        </div>
+      ) : (
+        <>
+          <code className="bg-base-200 flex-1 rounded px-2 py-1 text-sm">
+            {rule.pattern}
+          </code>
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs"
+            onClick={() => setIsEditing(true)}
+          >
+            編集
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs text-error"
+            onClick={() => void handleDelete()}
+          >
+            削除
+          </button>
+        </>
+      )}
+    </li>
+  );
+}

--- a/src/pages/SettingsPage/components/TagRuleList.tsx
+++ b/src/pages/SettingsPage/components/TagRuleList.tsx
@@ -1,0 +1,66 @@
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { type TagRule } from "../../../data/db";
+import { reorderTagRules } from "../../../data/tags/reorderTagRules";
+import { TagRuleItem } from "./TagRuleItem";
+
+type Props = {
+  rules: TagRule[];
+};
+
+export function TagRuleList({ rules }: Props) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    const oldIndex = rules.findIndex((rule) => rule.id === active.id);
+    const newIndex = rules.findIndex((rule) => rule.id === over.id);
+
+    const newOrder = [...rules];
+    const [removed] = newOrder.splice(oldIndex, 1);
+    newOrder.splice(newIndex, 0, removed);
+
+    await reorderTagRules({ ruleIds: newOrder.map((rule) => rule.id) });
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={(event) => void handleDragEnd(event)}
+    >
+      <SortableContext
+        items={rules.map((r) => r.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <ul className="flex flex-col gap-1">
+          {rules.map((rule) => (
+            <TagRuleItem key={rule.id} rule={rule} />
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,9 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as PaymentsFileNameRouteImport } from './routes/payments.$fileName'
 
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -25,32 +31,43 @@ const PaymentsFileNameRoute = PaymentsFileNameRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/settings': typeof SettingsRoute
   '/payments/$fileName': typeof PaymentsFileNameRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/settings': typeof SettingsRoute
   '/payments/$fileName': typeof PaymentsFileNameRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/settings': typeof SettingsRoute
   '/payments/$fileName': typeof PaymentsFileNameRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/payments/$fileName'
+  fullPaths: '/' | '/settings' | '/payments/$fileName'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/payments/$fileName'
-  id: '__root__' | '/' | '/payments/$fileName'
+  to: '/' | '/settings' | '/payments/$fileName'
+  id: '__root__' | '/' | '/settings' | '/payments/$fileName'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SettingsRoute: typeof SettingsRoute
   PaymentsFileNameRoute: typeof PaymentsFileNameRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -70,6 +87,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SettingsRoute: SettingsRoute,
   PaymentsFileNameRoute: PaymentsFileNameRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,9 +6,14 @@ export const Route = createRootRoute({
   component: () => (
     <>
       <div className="mx-auto max-w-7xl px-10 pt-5">
-        <h1 className="mb-5 text-xl font-bold">
-          <Link to="/">payview</Link>
-        </h1>
+        <div className="mb-5 flex items-center justify-between">
+          <h1 className="text-xl font-bold">
+            <Link to="/">payview</Link>
+          </h1>
+          <Link to="/settings" className="btn btn-ghost btn-sm">
+            設定
+          </Link>
+        </div>
 
         <Outlet />
       </div>

--- a/src/routes/payments.$fileName.tsx
+++ b/src/routes/payments.$fileName.tsx
@@ -3,7 +3,7 @@ import { DetailPage } from "../pages/DetailPage/DetailPage";
 import { z } from "zod";
 
 const SearchSchema = z.object({
-  tab: z.enum(["payments", "breakdown"]).default("payments"),
+  tab: z.enum(["payments", "breakdown", "tags"]).default("payments"),
 });
 
 export const Route = createFileRoute("/payments/$fileName")({

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SettingsPage } from "../pages/SettingsPage/SettingsPage";
+
+export const Route = createFileRoute("/settings")({
+  component: SettingsPage,
+});


### PR DESCRIPTION
## Summary
- タグとルールのデータモデルを追加（IndexedDB）
- タグ設定画面（/settings）を追加
- タグ別集計タブをDetailPageに追加

## 機能詳細
### タグ機能
- 項目名に対して部分一致でタグを付与
- 1アイテム1タグ（複数ルールがマッチした場合は最初にマッチしたタグを適用）
- タグルールはすべてのファイルに波及

### 設定画面（/settings）
- タグの追加・編集・削除
- ルール（マッチ文言）の追加・編集・削除
- ドラッグ&ドロップによる順序変更（@dnd-kit使用）

### タグ別タブ
- タグ別の集計結果を表示（棒グラフ + テーブル）
- 未分類アイテムは従来の内訳と同様に個別表示

## Test plan
- [ ] タグを追加できることを確認
- [ ] タグにルールを追加できることを確認
- [ ] タグ別タブで集計結果が表示されることを確認
- [ ] タグ/ルールの順序変更が動作することを確認
- [ ] タグ/ルールの編集・削除が動作することを確認

closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)