### PR TITLE
tags関連のユニットテストを追加

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,4 +32,11 @@ export default tseslint.config([
       globals: globals.browser,
     },
   },
+  {
+    files: ["**/*.test.ts", "**/*.test.tsx"],
+    rules: {
+      "@typescript-eslint/unbound-method": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+    },
+  },
 ]);

--- a/src/data/tags/addTag.test.ts
+++ b/src/data/tags/addTag.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { addTag, AddTagError } from "./addTag";
+
+vi.mock("../db", () => ({
+  db: {
+    tags: {
+      orderBy: vi.fn(),
+      add: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "../db";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("crypto", {
+    randomUUID: () => "test-uuid-1234",
+  });
+});
+
+test("正常系: タグが存在しない場合、order=0で追加される", async () => {
+  vi.mocked(db.tags.orderBy).mockReturnValue({
+    last: vi.fn().mockResolvedValue(undefined),
+  } as never);
+  vi.mocked(db.tags.add).mockResolvedValue("test-uuid-1234" as never);
+
+  const result = await addTag({ name: "食費" });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap()).toBe("test-uuid-1234");
+  expect(db.tags.add).toHaveBeenCalledWith({
+    id: "test-uuid-1234",
+    name: "食費",
+    order: 0,
+  });
+});
+
+test("正常系: 既存タグがある場合、order=maxOrder+1で追加される", async () => {
+  vi.mocked(db.tags.orderBy).mockReturnValue({
+    last: vi.fn().mockResolvedValue({ id: "existing", name: "既存", order: 5 }),
+  } as never);
+  vi.mocked(db.tags.add).mockResolvedValue("test-uuid-1234" as never);
+
+  const result = await addTag({ name: "交通費" });
+
+  expect(result.isOk()).toBe(true);
+  expect(db.tags.add).toHaveBeenCalledWith({
+    id: "test-uuid-1234",
+    name: "交通費",
+    order: 6,
+  });
+});
+
+test("異常系: DB操作でエラーが発生した場合", async () => {
+  vi.mocked(db.tags.orderBy).mockReturnValue({
+    last: vi.fn().mockRejectedValue(new Error("DB Error")),
+  } as never);
+
+  const result = await addTag({ name: "エラー" });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(AddTagError);
+  expect(result._unsafeUnwrapErr().message).toBe("タグの追加に失敗しました。");
+});

--- a/src/data/tags/addTagRule.test.ts
+++ b/src/data/tags/addTagRule.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { addTagRule, AddTagRuleError } from "./addTagRule";
+
+vi.mock("../db", () => ({
+  db: {
+    tagRules: {
+      where: vi.fn(),
+      add: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "../db";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("crypto", {
+    randomUUID: () => "test-rule-uuid-1234",
+  });
+});
+
+test("正常系: ルールが存在しない場合、order=0で追加される", async () => {
+  vi.mocked(db.tagRules.where).mockReturnValue({
+    equals: vi.fn().mockReturnValue({
+      sortBy: vi.fn().mockResolvedValue([]),
+    }),
+  } as never);
+  vi.mocked(db.tagRules.add).mockResolvedValue("test-rule-uuid-1234" as never);
+
+  const result = await addTagRule({ tagId: "tag-1", pattern: "スーパー.*" });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap()).toBe("test-rule-uuid-1234");
+  expect(db.tagRules.add).toHaveBeenCalledWith({
+    id: "test-rule-uuid-1234",
+    tagId: "tag-1",
+    pattern: "スーパー.*",
+    order: 0,
+  });
+});
+
+test("正常系: 既存ルールがある場合、order=maxOrder+1で追加される", async () => {
+  vi.mocked(db.tagRules.where).mockReturnValue({
+    equals: vi.fn().mockReturnValue({
+      sortBy: vi.fn().mockResolvedValue([
+        { id: "rule-1", tagId: "tag-1", pattern: "既存", order: 0 },
+        { id: "rule-2", tagId: "tag-1", pattern: "既存2", order: 3 },
+      ]),
+    }),
+  } as never);
+  vi.mocked(db.tagRules.add).mockResolvedValue("test-rule-uuid-1234" as never);
+
+  const result = await addTagRule({ tagId: "tag-1", pattern: "新規.*" });
+
+  expect(result.isOk()).toBe(true);
+  expect(db.tagRules.add).toHaveBeenCalledWith({
+    id: "test-rule-uuid-1234",
+    tagId: "tag-1",
+    pattern: "新規.*",
+    order: 4,
+  });
+});
+
+test("異常系: DB操作でエラーが発生した場合", async () => {
+  vi.mocked(db.tagRules.where).mockReturnValue({
+    equals: vi.fn().mockReturnValue({
+      sortBy: vi.fn().mockRejectedValue(new Error("DB Error")),
+    }),
+  } as never);
+
+  const result = await addTagRule({ tagId: "tag-1", pattern: "エラー" });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(AddTagRuleError);
+  expect(result._unsafeUnwrapErr().message).toBe(
+    "ルールの追加に失敗しました。",
+  );
+});

--- a/src/data/tags/deleteTag.test.ts
+++ b/src/data/tags/deleteTag.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { deleteTag, DeleteTagError } from "./deleteTag";
+
+const { mockTransaction, mockTagRulesWhere, mockTagsDelete } = vi.hoisted(
+  () => ({
+    mockTransaction: vi.fn(),
+    mockTagRulesWhere: vi.fn(),
+    mockTagsDelete: vi.fn(),
+  }),
+);
+
+vi.mock("../db", () => ({
+  db: {
+    transaction: mockTransaction,
+    tags: {
+      delete: mockTagsDelete,
+    },
+    tagRules: {
+      where: mockTagRulesWhere,
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: タグと関連ルールが削除される", async () => {
+  mockTransaction.mockImplementation(async (_mode, _tables, callback) => {
+    await callback();
+  });
+  mockTagRulesWhere.mockReturnValue({
+    equals: vi.fn().mockReturnValue({
+      delete: vi.fn().mockResolvedValue(2),
+    }),
+  });
+  mockTagsDelete.mockResolvedValue(undefined);
+
+  const result = await deleteTag({ id: "tag-1" });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap()).toBe(undefined);
+  expect(mockTransaction).toHaveBeenCalled();
+});
+
+test("異常系: トランザクションでエラーが発生した場合", async () => {
+  mockTransaction.mockRejectedValue(new Error("Transaction Error"));
+
+  const result = await deleteTag({ id: "tag-1" });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(DeleteTagError);
+  expect(result._unsafeUnwrapErr().message).toBe("タグの削除に失敗しました。");
+});

--- a/src/data/tags/deleteTagRule.test.ts
+++ b/src/data/tags/deleteTagRule.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { deleteTagRule, DeleteTagRuleError } from "./deleteTagRule";
+
+vi.mock("../db", () => ({
+  db: {
+    tagRules: {
+      delete: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "../db";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: ルールが削除される", async () => {
+  vi.mocked(db.tagRules.delete).mockResolvedValue(undefined as never);
+
+  const result = await deleteTagRule({ id: "rule-1" });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap()).toBe(undefined);
+  expect(db.tagRules.delete).toHaveBeenCalledWith("rule-1");
+});
+
+test("異常系: DB操作でエラーが発生した場合", async () => {
+  vi.mocked(db.tagRules.delete).mockRejectedValue(
+    new Error("DB Error") as never,
+  );
+
+  const result = await deleteTagRule({ id: "rule-1" });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(DeleteTagRuleError);
+  expect(result._unsafeUnwrapErr().message).toBe(
+    "ルールの削除に失敗しました。",
+  );
+});

--- a/src/data/tags/reorderTagRules.test.ts
+++ b/src/data/tags/reorderTagRules.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { reorderTagRules, ReorderTagRulesError } from "./reorderTagRules";
+
+const { mockTransaction, mockTagRulesUpdate } = vi.hoisted(() => ({
+  mockTransaction: vi.fn(),
+  mockTagRulesUpdate: vi.fn(),
+}));
+
+vi.mock("../db", () => ({
+  db: {
+    transaction: mockTransaction,
+    tagRules: {
+      update: mockTagRulesUpdate,
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: ルールの順序が更新される", async () => {
+  mockTransaction.mockImplementation(async (_mode, _table, callback) => {
+    await callback();
+  });
+  mockTagRulesUpdate.mockResolvedValue(1);
+
+  const result = await reorderTagRules({
+    ruleIds: ["rule-3", "rule-1", "rule-2"],
+  });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap()).toBe(undefined);
+  expect(mockTransaction).toHaveBeenCalled();
+});
+
+test("正常系: 空の配列でも正常に処理される", async () => {
+  mockTransaction.mockImplementation(async (_mode, _table, callback) => {
+    await callback();
+  });
+
+  const result = await reorderTagRules({ ruleIds: [] });
+
+  expect(result.isOk()).toBe(true);
+});
+
+test("異常系: トランザクションでエラーが発生した場合", async () => {
+  mockTransaction.mockRejectedValue(new Error("Transaction Error"));
+
+  const result = await reorderTagRules({ ruleIds: ["rule-1"] });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(ReorderTagRulesError);
+  expect(result._unsafeUnwrapErr().message).toBe(
+    "ルールの並び替えに失敗しました。",
+  );
+});

--- a/src/data/tags/reorderTags.test.ts
+++ b/src/data/tags/reorderTags.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { reorderTags, ReorderTagsError } from "./reorderTags";
+
+const { mockTransaction, mockTagsUpdate } = vi.hoisted(() => ({
+  mockTransaction: vi.fn(),
+  mockTagsUpdate: vi.fn(),
+}));
+
+vi.mock("../db", () => ({
+  db: {
+    transaction: mockTransaction,
+    tags: {
+      update: mockTagsUpdate,
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: タグの順序が更新される", async () => {
+  mockTransaction.mockImplementation(async (_mode, _table, callback) => {
+    await callback();
+  });
+  mockTagsUpdate.mockResolvedValue(1);
+
+  const result = await reorderTags({ tagIds: ["tag-3", "tag-1", "tag-2"] });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap()).toBe(undefined);
+  expect(mockTransaction).toHaveBeenCalled();
+});
+
+test("正常系: 空の配列でも正常に処理される", async () => {
+  mockTransaction.mockImplementation(async (_mode, _table, callback) => {
+    await callback();
+  });
+
+  const result = await reorderTags({ tagIds: [] });
+
+  expect(result.isOk()).toBe(true);
+});
+
+test("異常系: トランザクションでエラーが発生した場合", async () => {
+  mockTransaction.mockRejectedValue(new Error("Transaction Error"));
+
+  const result = await reorderTags({ tagIds: ["tag-1"] });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(ReorderTagsError);
+  expect(result._unsafeUnwrapErr().message).toBe(
+    "タグの並び替えに失敗しました。",
+  );
+});

--- a/src/data/tags/updateTag.test.ts
+++ b/src/data/tags/updateTag.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { updateTag, UpdateTagError } from "./updateTag";
+
+vi.mock("../db", () => ({
+  db: {
+    tags: {
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "../db";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: タグ名が更新される", async () => {
+  vi.mocked(db.tags.update).mockResolvedValue(1 as never);
+
+  const result = await updateTag({ id: "tag-1", name: "新しい名前" });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap()).toBe(undefined);
+  expect(db.tags.update).toHaveBeenCalledWith("tag-1", { name: "新しい名前" });
+});
+
+test("異常系: DB操作でエラーが発生した場合", async () => {
+  vi.mocked(db.tags.update).mockRejectedValue(new Error("DB Error") as never);
+
+  const result = await updateTag({ id: "tag-1", name: "エラー" });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(UpdateTagError);
+  expect(result._unsafeUnwrapErr().message).toBe("タグの更新に失敗しました。");
+});

--- a/src/data/tags/updateTagRule.test.ts
+++ b/src/data/tags/updateTagRule.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { updateTagRule, UpdateTagRuleError } from "./updateTagRule";
+
+vi.mock("../db", () => ({
+  db: {
+    tagRules: {
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "../db";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: ルールのパターンが更新される", async () => {
+  vi.mocked(db.tagRules.update).mockResolvedValue(1 as never);
+
+  const result = await updateTagRule({
+    id: "rule-1",
+    pattern: "新しいパターン.*",
+  });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap()).toBe(undefined);
+  expect(db.tagRules.update).toHaveBeenCalledWith("rule-1", {
+    pattern: "新しいパターン.*",
+  });
+});
+
+test("異常系: DB操作でエラーが発生した場合", async () => {
+  vi.mocked(db.tagRules.update).mockRejectedValue(
+    new Error("DB Error") as never,
+  );
+
+  const result = await updateTagRule({ id: "rule-1", pattern: "エラー" });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(UpdateTagRuleError);
+  expect(result._unsafeUnwrapErr().message).toBe(
+    "ルールの更新に失敗しました。",
+  );
+});


### PR DESCRIPTION
## Summary

- `src/data/tags/` 配下の全関数のユニットテストを追加
  - addTag, addTagRule
  - deleteTag, deleteTagRule
  - updateTag, updateTagRule
  - reorderTags, reorderTagRules
- ESLint設定にテストファイル用のルールを追加（`@typescript-eslint/unbound-method`, `@typescript-eslint/no-unsafe-call` を無効化）

## Test plan

- [x] 全テストが通ることを確認 (`npm test -- --run`) - 26テストパス
- [x] lint が通ることを確認 (`npm run lint`)
- [x] fmt が通ることを確認 (`npm run fmt:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)