### PR TITLE
data/ディレクトリのテストを追加

### DIFF
--- a/src/data/payments/deletePaymentFile.test.ts
+++ b/src/data/payments/deletePaymentFile.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { deletePaymentFile } from "./deletePaymentFile";
+
+vi.mock("../db", () => ({
+  db: {
+    paymentFiles: {
+      delete: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "../db";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: 指定したファイルが削除される", async () => {
+  vi.mocked(db.paymentFiles.delete).mockResolvedValue(undefined);
+
+  await deletePaymentFile("test.csv");
+
+  expect(db.paymentFiles.delete).toHaveBeenCalledWith("test.csv");
+});
+
+test("正常系: 存在しないファイル名でもエラーにならない", async () => {
+  vi.mocked(db.paymentFiles.delete).mockResolvedValue(undefined);
+
+  await deletePaymentFile("nonexistent.csv");
+
+  expect(db.paymentFiles.delete).toHaveBeenCalledWith("nonexistent.csv");
+});

--- a/src/data/payments/import/convertCsvDataToPaymentData.test.ts
+++ b/src/data/payments/import/convertCsvDataToPaymentData.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "vitest";
+import {
+  convertCsvDataToPaymentData,
+  ConvertCsvDataToPaymentDataInvalidSchemaError,
+} from "./convertCsvDataToPaymentData";
+
+test("正常系: 有効なCSVデータがPayment[]に変換される", () => {
+  const csvData = [
+    { date: "2023-01-01", name: "食費", price: "1000", count: "1" },
+    { date: "2023-01-02", name: "交通費", price: "500", count: "2" },
+  ];
+
+  const result = convertCsvDataToPaymentData({ csvData });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap().payments).toEqual([
+    { date: "2023-01-01", name: "食費", price: 1000, count: 1 },
+    { date: "2023-01-02", name: "交通費", price: 500, count: 2 },
+  ]);
+});
+
+test("正常系: price/countが文字列から数値に変換される", () => {
+  const csvData = [
+    { date: "2023-01-01", name: "テスト", price: "12345", count: "99" },
+  ];
+
+  const result = convertCsvDataToPaymentData({ csvData });
+
+  expect(result.isOk()).toBe(true);
+  const payment = result._unsafeUnwrap().payments[0];
+  expect(typeof payment.price).toBe("number");
+  expect(typeof payment.count).toBe("number");
+  expect(payment.price).toBe(12345);
+  expect(payment.count).toBe(99);
+});
+
+test("正常系: 空配列の場合、空のPayment[]を返す", () => {
+  const csvData: unknown[] = [];
+
+  const result = convertCsvDataToPaymentData({ csvData });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap().payments).toEqual([]);
+});
+
+test("異常系: 必須フィールドがない場合、InvalidSchemaErrorを返す", () => {
+  const csvData = [
+    { date: "2023-01-01", name: "食費" }, // price, count がない
+  ];
+
+  const result = convertCsvDataToPaymentData({ csvData });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+    ConvertCsvDataToPaymentDataInvalidSchemaError,
+  );
+});
+
+test("正常系: priceが数値に変換できない場合、NaNが返される", () => {
+  // parseInt("invalid") は NaN を返すが、Zodはエラーとして扱わない
+  const csvData = [
+    { date: "2023-01-01", name: "食費", price: "invalid", count: "1" },
+  ];
+
+  const result = convertCsvDataToPaymentData({ csvData });
+
+  expect(result.isOk()).toBe(true);
+  const payment = result._unsafeUnwrap().payments[0];
+  expect(payment.price).toBeNaN();
+});

--- a/src/data/payments/import/convertFileToCsvData.test.ts
+++ b/src/data/payments/import/convertFileToCsvData.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import {
+  convertFileToCsvData,
+  ConvertFileToCsvInvalidCsvError,
+  ConvertFileToCsvUnknownError,
+} from "./convertFileToCsvData";
+
+vi.mock("csv-parse/browser/esm/sync", () => ({
+  parse: vi.fn(),
+}));
+
+vi.mock("encoding-japanese", () => ({
+  default: {
+    convert: vi.fn(),
+  },
+}));
+
+import { parse } from "csv-parse/browser/esm/sync";
+import Encoding from "encoding-japanese";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function createMockFile(content: string, name: string): File {
+  const file = new File([content], name, { type: "text/csv" });
+  // jsdom環境でarrayBuffer()が存在しない場合があるため、definePropertyで追加
+  Object.defineProperty(file, "arrayBuffer", {
+    value: () => Promise.resolve(new TextEncoder().encode(content).buffer),
+    writable: true,
+  });
+  return file;
+}
+
+test("正常系: CSVファイルがパースされる", async () => {
+  const mockCsvData = [
+    {
+      date: "2023-01-01",
+      name: "食費",
+      price: "1000",
+      count: "1",
+      noname1: "",
+      noname2: "",
+      noname3: "",
+    },
+  ];
+  vi.mocked(Encoding.convert).mockReturnValue([]);
+  vi.mocked(parse).mockReturnValue(mockCsvData as never);
+
+  const file = createMockFile("dummy", "test.csv");
+  const result = await convertFileToCsvData({ file });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap().csvData).toEqual(mockCsvData);
+});
+
+test("正常系: 複数行のCSVがパースされる", async () => {
+  const mockCsvData = [
+    { date: "2023-01-01", name: "食費", price: "1000", count: "1" },
+    { date: "2023-01-02", name: "交通費", price: "500", count: "2" },
+  ];
+  vi.mocked(Encoding.convert).mockReturnValue([]);
+  vi.mocked(parse).mockReturnValue(mockCsvData as never);
+
+  const file = createMockFile("dummy", "test.csv");
+  const result = await convertFileToCsvData({ file });
+
+  expect(result.isOk()).toBe(true);
+  expect(result._unsafeUnwrap().csvData).toHaveLength(2);
+});
+
+test("異常系: CSVが空の場合、ConvertFileToCsvInvalidCsvErrorを返す", async () => {
+  vi.mocked(Encoding.convert).mockReturnValue([]);
+  vi.mocked(parse).mockReturnValue([]);
+
+  const file = createMockFile("", "empty.csv");
+  const result = await convertFileToCsvData({ file });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+    ConvertFileToCsvInvalidCsvError,
+  );
+  expect(result._unsafeUnwrapErr().message).toBe(
+    "ファイルのデータを読み取れませんでした。",
+  );
+});
+
+test("異常系: パース中にエラーが発生した場合、ConvertFileToCsvUnknownErrorを返す", async () => {
+  vi.mocked(Encoding.convert).mockReturnValue([]);
+  vi.mocked(parse).mockImplementation(() => {
+    throw new Error("Parse error");
+  });
+
+  const file = createMockFile("invalid", "test.csv");
+  const result = await convertFileToCsvData({ file });
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+    ConvertFileToCsvUnknownError,
+  );
+});

--- a/src/data/payments/import/createPayments.test.ts
+++ b/src/data/payments/import/createPayments.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import {
+  createPayments,
+  CreatePaymentsConstraintError,
+  CreatePaymentsUnknownError,
+} from "./createPayments";
+
+vi.mock("../../db", () => ({
+  db: {
+    paymentFiles: {
+      bulkAdd: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "../../db";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: 支払いデータがDBに登録される", async () => {
+  vi.mocked(db.paymentFiles.bulkAdd).mockResolvedValue(undefined as never);
+
+  const result = await createPayments([
+    {
+      fileName: "test.csv",
+      payments: [{ date: "2023-01-01", name: "食費", price: 1000, count: 1 }],
+    },
+  ]);
+
+  expect(result.isOk()).toBe(true);
+  expect(db.paymentFiles.bulkAdd).toHaveBeenCalledWith([
+    {
+      fileName: "test.csv",
+      payments: [{ date: "2023-01-01", name: "食費", price: 1000, count: 1 }],
+    },
+  ]);
+});
+
+test("異常系: 重複ファイルの場合、CreatePaymentsConstraintErrorを返す", async () => {
+  const constraintError = new Error("ConstraintError");
+  constraintError.name = "ConstraintError";
+  vi.mocked(db.paymentFiles.bulkAdd).mockRejectedValue(constraintError);
+
+  const result = await createPayments([
+    {
+      fileName: "duplicate.csv",
+      payments: [{ date: "2023-01-01", name: "食費", price: 1000, count: 1 }],
+    },
+  ]);
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+    CreatePaymentsConstraintError,
+  );
+  expect(result._unsafeUnwrapErr().message).toBe(
+    "ファイルは既に登録されています。別のファイルを選択してください。",
+  );
+});
+
+test("異常系: その他のエラーの場合、CreatePaymentsUnknownErrorを返す", async () => {
+  vi.mocked(db.paymentFiles.bulkAdd).mockRejectedValue(
+    new Error("Unknown error"),
+  );
+
+  const result = await createPayments([
+    {
+      fileName: "test.csv",
+      payments: [{ date: "2023-01-01", name: "食費", price: 1000, count: 1 }],
+    },
+  ]);
+
+  expect(result.isErr()).toBe(true);
+  expect(result._unsafeUnwrapErr()).toBeInstanceOf(CreatePaymentsUnknownError);
+  expect(result._unsafeUnwrapErr().message).toBe(
+    "不明なエラーが発生しました。",
+  );
+});

--- a/src/data/payments/usePayments.test.ts
+++ b/src/data/payments/usePayments.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { usePayments } from "./usePayments";
+
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: vi.fn(),
+}));
+
+import { useLiveQuery } from "dexie-react-hooks";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: ローディング中はstatus=loadingを返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue(undefined);
+
+  const { result } = renderHook(() => usePayments({ fileName: "test.csv" }));
+
+  expect(result.current).toEqual({ status: "loading" });
+});
+
+test("正常系: ファイルが見つからない場合もstatus=loadingを返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue([]);
+
+  const { result } = renderHook(() => usePayments({ fileName: "test.csv" }));
+
+  expect(result.current).toEqual({ status: "loading" });
+});
+
+test("正常系: データ取得後はstatus=completedとpaymentsを返す", () => {
+  const mockPayments = [
+    { date: "2023-01-01", name: "食費", price: 1000, count: 1 },
+    { date: "2023-01-02", name: "交通費", price: 500, count: 2 },
+  ];
+  vi.mocked(useLiveQuery).mockReturnValue([
+    { fileName: "test.csv", payments: mockPayments },
+  ]);
+
+  const { result } = renderHook(() => usePayments({ fileName: "test.csv" }));
+
+  expect(result.current).toEqual({
+    status: "completed",
+    payments: mockPayments,
+  });
+});

--- a/src/data/payments/usePaymentsBreakdown.test.ts
+++ b/src/data/payments/usePaymentsBreakdown.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { usePaymentsBreakdown } from "./usePaymentsBreakdown";
+
+vi.mock("./usePayments");
+
+import { usePayments } from "./usePayments";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: ローディング中はstatus=loadingを返す", () => {
+  vi.mocked(usePayments).mockReturnValue({ status: "loading" });
+
+  const { result } = renderHook(() =>
+    usePaymentsBreakdown({ fileName: "test.csv" }),
+  );
+
+  expect(result.current).toEqual({ status: "loading" });
+});
+
+test("正常系: 同一名の支払いが合算される", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      { date: "2023-01-01", name: "食費", price: 1000, count: 1 },
+      { date: "2023-01-02", name: "食費", price: 500, count: 1 },
+      { date: "2023-01-03", name: "交通費", price: 300, count: 1 },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsBreakdown({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    const food = result.current.breakdown.find((b) => b.name === "食費");
+    expect(food?.total).toBe(1500);
+  }
+});
+
+test("正常系: breakdownはtotalの降順でソートされる", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      { date: "2023-01-01", name: "小額", price: 100, count: 1 },
+      { date: "2023-01-02", name: "中額", price: 500, count: 1 },
+      { date: "2023-01-03", name: "高額", price: 1000, count: 1 },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsBreakdown({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.breakdown[0].name).toBe("高額");
+    expect(result.current.breakdown[1].name).toBe("中額");
+    expect(result.current.breakdown[2].name).toBe("小額");
+  }
+});
+
+test("正常系: 空の支払いリストの場合、空のbreakdownを返す", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsBreakdown({ fileName: "test.csv" }),
+  );
+
+  expect(result.current).toEqual({ status: "completed", breakdown: [] });
+});

--- a/src/data/payments/usePaymentsByTag.test.ts
+++ b/src/data/payments/usePaymentsByTag.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { usePaymentsByTag } from "./usePaymentsByTag";
+
+vi.mock("./usePayments");
+vi.mock("../tags/useAllTagRules");
+
+import { usePayments } from "./usePayments";
+import { useAllTagRules } from "../tags/useAllTagRules";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: paymentsがローディング中はstatus=loadingを返す", () => {
+  vi.mocked(usePayments).mockReturnValue({ status: "loading" });
+  vi.mocked(useAllTagRules).mockReturnValue({
+    status: "completed",
+    tagsWithRules: [],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByTag({ fileName: "test.csv" }),
+  );
+
+  expect(result.current).toEqual({ status: "loading" });
+});
+
+test("正常系: tagsResultがローディング中はstatus=loadingを返す", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [],
+  });
+  vi.mocked(useAllTagRules).mockReturnValue({ status: "loading" });
+
+  const { result } = renderHook(() =>
+    usePaymentsByTag({ fileName: "test.csv" }),
+  );
+
+  expect(result.current).toEqual({ status: "loading" });
+});
+
+test("正常系: 支払い名がパターンに一致する場合、対応するタグに集計される", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      { date: "2023-01-01", name: "スーパーマーケット", price: 1000, count: 1 },
+      { date: "2023-01-02", name: "コンビニエンス", price: 500, count: 1 },
+    ],
+  });
+  vi.mocked(useAllTagRules).mockReturnValue({
+    status: "completed",
+    tagsWithRules: [
+      {
+        id: "tag-1",
+        name: "食費",
+        order: 0,
+        rules: [
+          { id: "rule-1", tagId: "tag-1", pattern: "スーパー", order: 0 },
+          { id: "rule-2", tagId: "tag-1", pattern: "コンビニ", order: 1 },
+        ],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByTag({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.breakdown).toHaveLength(1);
+    expect(result.current.breakdown[0].tag?.name).toBe("食費");
+    expect(result.current.breakdown[0].total).toBe(1500);
+    expect(result.current.breakdown[0].count).toBe(2);
+  }
+});
+
+test("正常系: 複数ルールがある場合、最初にマッチしたタグに割り当てられる", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      { date: "2023-01-01", name: "スーパー食品", price: 1000, count: 1 },
+    ],
+  });
+  vi.mocked(useAllTagRules).mockReturnValue({
+    status: "completed",
+    tagsWithRules: [
+      {
+        id: "tag-1",
+        name: "食費",
+        order: 0,
+        rules: [
+          { id: "rule-1", tagId: "tag-1", pattern: "スーパー", order: 0 },
+        ],
+      },
+      {
+        id: "tag-2",
+        name: "日用品",
+        order: 1,
+        rules: [{ id: "rule-2", tagId: "tag-2", pattern: "食品", order: 0 }],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByTag({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.breakdown).toHaveLength(1);
+    expect(result.current.breakdown[0].tag?.name).toBe("食費");
+  }
+});
+
+test("正常系: どのパターンにもマッチしない場合、未タグとして集計される", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      { date: "2023-01-01", name: "謎の支払い", price: 1000, count: 1 },
+    ],
+  });
+  vi.mocked(useAllTagRules).mockReturnValue({
+    status: "completed",
+    tagsWithRules: [
+      {
+        id: "tag-1",
+        name: "食費",
+        order: 0,
+        rules: [
+          { id: "rule-1", tagId: "tag-1", pattern: "スーパー", order: 0 },
+        ],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByTag({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.breakdown).toHaveLength(1);
+    expect(result.current.breakdown[0].tag).toBeNull();
+    expect(result.current.breakdown[0].name).toBe("謎の支払い");
+  }
+});
+
+test("正常系: 同一タグの支払いが合算される", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      { date: "2023-01-01", name: "スーパーA", price: 1000, count: 1 },
+      { date: "2023-01-02", name: "スーパーB", price: 2000, count: 1 },
+    ],
+  });
+  vi.mocked(useAllTagRules).mockReturnValue({
+    status: "completed",
+    tagsWithRules: [
+      {
+        id: "tag-1",
+        name: "食費",
+        order: 0,
+        rules: [
+          { id: "rule-1", tagId: "tag-1", pattern: "スーパー", order: 0 },
+        ],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByTag({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.breakdown[0].total).toBe(3000);
+    expect(result.current.breakdown[0].count).toBe(2);
+  }
+});
+
+test("正常系: breakdownはtotalの降順でソートされる", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      { date: "2023-01-01", name: "スーパー", price: 500, count: 1 },
+      { date: "2023-01-02", name: "電車", price: 1000, count: 1 },
+    ],
+  });
+  vi.mocked(useAllTagRules).mockReturnValue({
+    status: "completed",
+    tagsWithRules: [
+      {
+        id: "tag-1",
+        name: "食費",
+        order: 0,
+        rules: [
+          { id: "rule-1", tagId: "tag-1", pattern: "スーパー", order: 0 },
+        ],
+      },
+      {
+        id: "tag-2",
+        name: "交通費",
+        order: 1,
+        rules: [{ id: "rule-2", tagId: "tag-2", pattern: "電車", order: 0 }],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByTag({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.breakdown[0].tag?.name).toBe("交通費");
+    expect(result.current.breakdown[1].tag?.name).toBe("食費");
+  }
+});
+
+test("正常系: タグはあるがルールがない場合、全て未タグになる", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [{ date: "2023-01-01", name: "スーパー", price: 1000, count: 1 }],
+  });
+  vi.mocked(useAllTagRules).mockReturnValue({
+    status: "completed",
+    tagsWithRules: [
+      {
+        id: "tag-1",
+        name: "食費",
+        order: 0,
+        rules: [],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByTag({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.breakdown).toHaveLength(1);
+    expect(result.current.breakdown[0].tag).toBeNull();
+  }
+});
+
+test("正常系: 支払いがない場合、空のbreakdownを返す", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [],
+  });
+  vi.mocked(useAllTagRules).mockReturnValue({
+    status: "completed",
+    tagsWithRules: [
+      {
+        id: "tag-1",
+        name: "食費",
+        order: 0,
+        rules: [
+          { id: "rule-1", tagId: "tag-1", pattern: "スーパー", order: 0 },
+        ],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByTag({ fileName: "test.csv" }),
+  );
+
+  expect(result.current).toEqual({ status: "completed", breakdown: [] });
+});

--- a/src/data/payments/usePaymentsFiles.test.ts
+++ b/src/data/payments/usePaymentsFiles.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { usePaymentsFiles } from "./usePaymentsFiles";
+
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: vi.fn(),
+}));
+
+import { useLiveQuery } from "dexie-react-hooks";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: ローディング中はundefinedを返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue(undefined);
+
+  const { result } = renderHook(() => usePaymentsFiles());
+
+  expect(result.current).toBeUndefined();
+});
+
+test("正常系: 全ファイル一覧が取得される", () => {
+  const mockFiles = [
+    {
+      fileName: "test1.csv",
+      payments: [{ date: "2023-01-01", name: "食費", price: 1000, count: 1 }],
+    },
+    {
+      fileName: "test2.csv",
+      payments: [{ date: "2023-02-01", name: "交通費", price: 500, count: 2 }],
+    },
+  ];
+  vi.mocked(useLiveQuery).mockReturnValue(mockFiles);
+
+  const { result } = renderHook(() => usePaymentsFiles());
+
+  expect(result.current).toEqual(mockFiles);
+});
+
+test("正常系: ファイルがない場合は空配列を返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue([]);
+
+  const { result } = renderHook(() => usePaymentsFiles());
+
+  expect(result.current).toEqual([]);
+});

--- a/src/data/tags/useAllTagRules.test.ts
+++ b/src/data/tags/useAllTagRules.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAllTagRules } from "./useAllTagRules";
+
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: vi.fn(),
+}));
+
+import { useLiveQuery } from "dexie-react-hooks";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: ローディング中はstatus=loadingを返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue(undefined);
+
+  const { result } = renderHook(() => useAllTagRules());
+
+  expect(result.current).toEqual({ status: "loading" });
+});
+
+test("正常系: tagsWithRulesが正しく返される", () => {
+  const mockTagsWithRules = [
+    {
+      id: "tag-1",
+      name: "食費",
+      order: 0,
+      rules: [
+        { id: "rule-1", tagId: "tag-1", pattern: "スーパー", order: 0 },
+        { id: "rule-2", tagId: "tag-1", pattern: "コンビニ", order: 1 },
+      ],
+    },
+    {
+      id: "tag-2",
+      name: "交通費",
+      order: 1,
+      rules: [{ id: "rule-3", tagId: "tag-2", pattern: "電車", order: 0 }],
+    },
+  ];
+  vi.mocked(useLiveQuery).mockReturnValue(mockTagsWithRules);
+
+  const { result } = renderHook(() => useAllTagRules());
+
+  expect(result.current).toEqual({
+    status: "completed",
+    tagsWithRules: mockTagsWithRules,
+  });
+});
+
+test("正常系: ルールがないタグはrules=[]で返される", () => {
+  const mockTagsWithRules = [
+    {
+      id: "tag-1",
+      name: "食費",
+      order: 0,
+      rules: [],
+    },
+  ];
+  vi.mocked(useLiveQuery).mockReturnValue(mockTagsWithRules);
+
+  const { result } = renderHook(() => useAllTagRules());
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.tagsWithRules[0].rules).toEqual([]);
+  }
+});
+
+test("正常系: タグがない場合は空配列を返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue([]);
+
+  const { result } = renderHook(() => useAllTagRules());
+
+  expect(result.current).toEqual({ status: "completed", tagsWithRules: [] });
+});

--- a/src/data/tags/useTagRules.test.ts
+++ b/src/data/tags/useTagRules.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useTagRules } from "./useTagRules";
+
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: vi.fn(),
+}));
+
+import { useLiveQuery } from "dexie-react-hooks";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: ローディング中はstatus=loadingを返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue(undefined);
+
+  const { result } = renderHook(() => useTagRules({ tagId: "tag-1" }));
+
+  expect(result.current).toEqual({ status: "loading" });
+});
+
+test("正常系: データ取得後はstatus=completedとrulesを返す", () => {
+  const mockRules = [
+    { id: "rule-1", tagId: "tag-1", pattern: "パターン1", order: 0 },
+    { id: "rule-2", tagId: "tag-1", pattern: "パターン2", order: 1 },
+  ];
+  vi.mocked(useLiveQuery).mockReturnValue(mockRules);
+
+  const { result } = renderHook(() => useTagRules({ tagId: "tag-1" }));
+
+  expect(result.current).toEqual({ status: "completed", rules: mockRules });
+});
+
+test("正常系: ルールがない場合は空配列を返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue([]);
+
+  const { result } = renderHook(() => useTagRules({ tagId: "tag-1" }));
+
+  expect(result.current).toEqual({ status: "completed", rules: [] });
+});

--- a/src/data/tags/useTags.test.ts
+++ b/src/data/tags/useTags.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useTags } from "./useTags";
+
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: vi.fn(),
+}));
+
+import { useLiveQuery } from "dexie-react-hooks";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: ローディング中はstatus=loadingを返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue(undefined);
+
+  const { result } = renderHook(() => useTags());
+
+  expect(result.current).toEqual({ status: "loading" });
+});
+
+test("正常系: データ取得後はstatus=completedとtagsを返す", () => {
+  const mockTags = [
+    { id: "tag-1", name: "食費", order: 0 },
+    { id: "tag-2", name: "交通費", order: 1 },
+  ];
+  vi.mocked(useLiveQuery).mockReturnValue(mockTags);
+
+  const { result } = renderHook(() => useTags());
+
+  expect(result.current).toEqual({ status: "completed", tags: mockTags });
+});
+
+test("正常系: 空配列の場合もstatus=completedを返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue([]);
+
+  const { result } = renderHook(() => useTags());
+
+  expect(result.current).toEqual({ status: "completed", tags: [] });
+});

--- a/src/data/utils/getNextOrder.test.ts
+++ b/src/data/utils/getNextOrder.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { getNextOrder } from "./getNextOrder";
+
+vi.mock("../db", () => ({
+  db: {
+    tags: {
+      orderBy: vi.fn(),
+    },
+    tagRules: {
+      where: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "../db";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: tags - タグが存在しない場合、0を返す", async () => {
+  vi.mocked(db.tags.orderBy).mockReturnValue({
+    last: vi.fn().mockResolvedValue(undefined),
+  } as never);
+
+  const result = await getNextOrder("tags");
+
+  expect(result).toBe(0);
+  expect(db.tags.orderBy).toHaveBeenCalledWith("order");
+});
+
+test("正常系: tags - 既存タグがある場合、maxOrder+1を返す", async () => {
+  vi.mocked(db.tags.orderBy).mockReturnValue({
+    last: vi.fn().mockResolvedValue({ id: "tag-1", name: "食費", order: 5 }),
+  } as never);
+
+  const result = await getNextOrder("tags");
+
+  expect(result).toBe(6);
+});
+
+test("正常系: tagRules - フィルタありでルールが存在しない場合、0を返す", async () => {
+  vi.mocked(db.tagRules.where).mockReturnValue({
+    equals: vi.fn().mockReturnValue({
+      sortBy: vi.fn().mockResolvedValue([]),
+    }),
+  } as never);
+
+  const result = await getNextOrder("tagRules", {
+    where: "tagId",
+    equals: "tag-1",
+  });
+
+  expect(result).toBe(0);
+  expect(db.tagRules.where).toHaveBeenCalledWith("tagId");
+});
+
+test("正常系: tagRules - フィルタありで既存ルールがある場合、maxOrder+1を返す", async () => {
+  vi.mocked(db.tagRules.where).mockReturnValue({
+    equals: vi.fn().mockReturnValue({
+      sortBy: vi.fn().mockResolvedValue([
+        { id: "rule-1", tagId: "tag-1", pattern: "パターン1", order: 2 },
+        { id: "rule-2", tagId: "tag-1", pattern: "パターン2", order: 5 },
+      ]),
+    }),
+  } as never);
+
+  const result = await getNextOrder("tagRules", {
+    where: "tagId",
+    equals: "tag-1",
+  });
+
+  expect(result).toBe(6);
+});
+
+test("正常系: tagRules - フィルタなしの場合、0を返す", async () => {
+  const result = await getNextOrder("tagRules");
+
+  expect(result).toBe(0);
+  expect(db.tagRules.where).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- data/ディレクトリの未テスト機能にテストを追加
- 12ファイル、48テストケースを追加（既存26 → 計74テスト）
- 純粋関数（getNextOrder, deletePaymentFile, createPayments, convertCsvDataToPaymentData, convertFileToCsvData）
- React Hooks（useTags, useTagRules, useAllTagRules, usePayments, usePaymentsFiles, usePaymentsBreakdown, usePaymentsByTag）

## Test plan
- [ ] `npm test` が全テストパス
- [ ] `npm run lint` がエラーなし
- [ ] `npm run fmt:check` がエラーなし
- [ ] `npm run build` が成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)