### PR TITLE
タグ別内訳で個別支払い明細を展開表示できる機能を追加

### DIFF
--- a/src/data/payments/usePaymentsByTag.test.ts
+++ b/src/data/payments/usePaymentsByTag.test.ts
@@ -144,10 +144,16 @@ test("正常系: どのパターンにもマッチしない場合、未タグと
     expect(result.current.breakdown).toHaveLength(1);
     expect(result.current.breakdown[0].tag).toBeNull();
     expect(result.current.breakdown[0].name).toBe("謎の支払い");
+    expect(result.current.breakdown[0].payments).toHaveLength(1);
+    expect(result.current.breakdown[0].payments[0]).toEqual({
+      name: "謎の支払い",
+      date: "2023-01-01",
+      price: 1000,
+    });
   }
 });
 
-test("正常系: 同一タグの支払いが合算される", () => {
+test("正常系: 同一タグの支払いが合算され、個別支払いがpaymentsに含まれる", () => {
   vi.mocked(usePayments).mockReturnValue({
     status: "completed",
     payments: [
@@ -177,6 +183,17 @@ test("正常系: 同一タグの支払いが合算される", () => {
   if (result.current.status === "completed") {
     expect(result.current.breakdown[0].total).toBe(3000);
     expect(result.current.breakdown[0].count).toBe(2);
+    expect(result.current.breakdown[0].payments).toHaveLength(2);
+    expect(result.current.breakdown[0].payments[0]).toEqual({
+      name: "スーパーA",
+      date: "2023-01-01",
+      price: 1000,
+    });
+    expect(result.current.breakdown[0].payments[1]).toEqual({
+      name: "スーパーB",
+      date: "2023-01-02",
+      price: 2000,
+    });
   }
 });
 

--- a/src/data/payments/usePaymentsByTag.ts
+++ b/src/data/payments/usePaymentsByTag.ts
@@ -11,11 +11,18 @@ type TagInfo = {
   name: string;
 } | null;
 
+type PaymentDetail = {
+  name: string;
+  date: string;
+  price: number;
+};
+
 type TagBreakdownItem = {
   tag: TagInfo;
   total: number;
   count: number;
   name?: string;
+  payments: PaymentDetail[];
 };
 
 type UsePaymentsByTagResult =
@@ -46,12 +53,20 @@ export function usePaymentsByTag({ fileName }: Props): UsePaymentsByTagResult {
 
     const tagTotals = new Map<
       string,
-      { tag: TagInfo; total: number; count: number }
+      { tag: TagInfo; total: number; count: number; payments: PaymentDetail[] }
     >();
-    const untaggedTotals = new Map<string, { total: number; count: number }>();
+    const untaggedTotals = new Map<
+      string,
+      { total: number; count: number; payments: PaymentDetail[] }
+    >();
 
     for (const payment of payments.payments) {
       const tag = findTagForPayment(payment.name);
+      const paymentDetail: PaymentDetail = {
+        name: payment.name,
+        date: payment.date,
+        price: payment.price,
+      };
 
       if (tag) {
         const key = tag.id;
@@ -59,16 +74,27 @@ export function usePaymentsByTag({ fileName }: Props): UsePaymentsByTagResult {
         if (existing) {
           existing.total += payment.price;
           existing.count += 1;
+          existing.payments.push(paymentDetail);
         } else {
-          tagTotals.set(key, { tag, total: payment.price, count: 1 });
+          tagTotals.set(key, {
+            tag,
+            total: payment.price,
+            count: 1,
+            payments: [paymentDetail],
+          });
         }
       } else {
         const existing = untaggedTotals.get(payment.name);
         if (existing) {
           existing.total += payment.price;
           existing.count += 1;
+          existing.payments.push(paymentDetail);
         } else {
-          untaggedTotals.set(payment.name, { total: payment.price, count: 1 });
+          untaggedTotals.set(payment.name, {
+            total: payment.price,
+            count: 1,
+            payments: [paymentDetail],
+          });
         }
       }
     }
@@ -76,11 +102,12 @@ export function usePaymentsByTag({ fileName }: Props): UsePaymentsByTagResult {
     const taggedBreakdown = Array.from(tagTotals.values());
     const untaggedBreakdown: TagBreakdownItem[] = Array.from(
       untaggedTotals.entries(),
-    ).map(([name, { total, count }]) => ({
+    ).map(([name, { total, count, payments }]) => ({
       tag: null,
       total,
       count,
       name,
+      payments,
     }));
 
     const allBreakdown = [...taggedBreakdown, ...untaggedBreakdown];

--- a/src/pages/DetailPage/components/PaymentTagView/PaymentDetailTable.tsx
+++ b/src/pages/DetailPage/components/PaymentTagView/PaymentDetailTable.tsx
@@ -1,0 +1,34 @@
+type PaymentDetail = {
+  name: string;
+  date: string;
+  price: number;
+};
+
+type Props = {
+  payments: PaymentDetail[];
+};
+
+export function PaymentDetailTable({ payments }: Props) {
+  return (
+    <div className="bg-base-200 p-2">
+      <table className="table-sm table">
+        <thead>
+          <tr>
+            <th>利用日</th>
+            <th>項目</th>
+            <th>金額</th>
+          </tr>
+        </thead>
+        <tbody>
+          {payments.map((payment, idx) => (
+            <tr key={`${payment.date}-${payment.name}-${idx}`}>
+              <td>{payment.date}</td>
+              <td>{payment.name}</td>
+              <td>{payment.price.toLocaleString()} 円</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/DetailPage/components/PaymentTagView/PaymentTagView.tsx
+++ b/src/pages/DetailPage/components/PaymentTagView/PaymentTagView.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { usePaymentsByTag } from "../../../../data/payments";
 import { PayviewTagBarChart } from "./PayviewTagBarChart";
+import { TagBreakdownRow } from "./TagBreakdownRow";
 
 type Props = {
   fileName: string;
@@ -57,21 +58,11 @@ export function PaymentTagView({ fileName }: Props) {
                 </thead>
                 <tbody>
                   {breakdown.map((item, index) => (
-                    <tr key={item.tag?.id || `untagged-${index}`}>
-                      <td>
-                        {item.tag ? (
-                          <span className="badge badge-primary">
-                            {item.tag.name}
-                          </span>
-                        ) : (
-                          <span className="text-base-content/60">
-                            {item.name}
-                          </span>
-                        )}
-                      </td>
-                      <td>{item.count} 件</td>
-                      <td>{item.total.toLocaleString()} 円</td>
-                    </tr>
+                    <TagBreakdownRow
+                      key={item.tag?.id || `untagged-${index}`}
+                      item={item}
+                      index={index}
+                    />
                   ))}
                 </tbody>
               </table>

--- a/src/pages/DetailPage/components/PaymentTagView/TagBreakdownRow.tsx
+++ b/src/pages/DetailPage/components/PaymentTagView/TagBreakdownRow.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { PaymentDetailTable } from "./PaymentDetailTable";
+
+type PaymentDetail = {
+  name: string;
+  date: string;
+  price: number;
+};
+
+type TagInfo = {
+  id: string;
+  name: string;
+} | null;
+
+type TagBreakdownItem = {
+  tag: TagInfo;
+  total: number;
+  count: number;
+  name?: string;
+  payments: PaymentDetail[];
+};
+
+type Props = {
+  item: TagBreakdownItem;
+  index: number;
+};
+
+export function TagBreakdownRow({ item, index }: Props) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <>
+      <tr
+        key={item.tag?.id || `untagged-${index}`}
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="hover:bg-base-200 cursor-pointer"
+      >
+        <td>
+          <span className="text-base-content/60 mr-2">
+            {isExpanded ? "▼" : "▶"}
+          </span>
+          {item.tag ? (
+            <span className="badge badge-primary">{item.tag.name}</span>
+          ) : (
+            <span className="text-base-content/60">{item.name}</span>
+          )}
+        </td>
+        <td>{item.count} 件</td>
+        <td>{item.total.toLocaleString()} 円</td>
+      </tr>
+
+      {isExpanded && (
+        <tr>
+          <td colSpan={3} className="p-0">
+            <PaymentDetailTable payments={item.payments} />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- タグ別内訳テーブルの各行をクリックすると、そのタグに含まれる個別の支払い明細を確認できる機能を追加
- `usePaymentsByTag`フックの戻り値に個別支払いデータ（`payments`配列）を追加
- 展開/折りたたみ可能な`TagBreakdownRow`コンポーネントと、詳細テーブル`PaymentDetailTable`を新規作成

## Test plan
- [ ] タグ別タブで各タグ行をクリックして展開できることを確認
- [ ] 展開時に個別支払い（利用日、項目、金額）が表示されることを確認
- [ ] 再度クリックして折りたためることを確認
- [ ] 未タグ付きの行でも同様に動作することを確認
- [ ] `npm test` が全てパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)