### PR TITLE
設定ページから戻るボタンを削除

### DIFF
--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@tanstack/react-router";
 import { useTags } from "../../data/tags/useTags";
 import { TagList } from "./components/TagList";
 import { AddTagForm } from "./components/AddTagForm";
@@ -8,12 +7,7 @@ export function SettingsPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center gap-4">
-        <Link to="/" className="btn btn-ghost btn-sm">
-          ← 戻る
-        </Link>
-        <h1 className="text-primary-content text-xl">タグ設定</h1>
-      </div>
+      <h1 className="text-primary-content text-xl">タグ設定</h1>
 
       <div className="text-info text-sm">
         <p>タグを設定すると、項目名に含まれる文言でグループ分けができます。</p>


### PR DESCRIPTION
## Summary
- 設定ページの「← 戻る」ボタンを削除
- ブラウザの戻るボタンとヘッダーの「payview」リンクでナビゲーション可能なため、冗長な UI を削除

## Test plan
- [ ] 設定ページにアクセスし、戻るボタンがないことを確認
- [ ] ブラウザの戻るボタンで前のページに戻れることを確認
- [ ] ヘッダーの「payview」リンクでホームに戻れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)