### PR TITLE
ヘッダー部分をセマンティックなheader要素に変更

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,14 +7,14 @@ export const Route = createRootRoute({
     <>
       <div className="flex min-h-screen flex-col">
         <div className="mx-auto w-full max-w-7xl flex-grow px-10 pt-5 pb-10">
-          <div className="mb-5 flex items-center justify-between">
+          <header className="mb-5 flex items-center justify-between">
             <h1 className="text-xl font-bold">
               <Link to="/">payview</Link>
             </h1>
             <Link to="/settings" className="btn btn-ghost btn-sm">
               設定
             </Link>
-          </div>
+          </header>
 
           <Outlet />
         </div>


### PR DESCRIPTION
## Summary
- ヘッダー部分の`<div>`を`<header>`要素に変更
- footerと対になるセマンティックなHTML構造に改善

## Test plan
- [ ] ページが正常に表示されることを確認
- [ ] ヘッダーの見た目・レイアウトに変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)