### PR TITLE
詳細ページ間で移動できるナビゲーションを追加

### DIFF
--- a/src/pages/DetailPage/components/FileNavigation.tsx
+++ b/src/pages/DetailPage/components/FileNavigation.tsx
@@ -1,0 +1,53 @@
+import { Link } from "@tanstack/react-router";
+import { useFileNavigation } from "../hooks/useFileNavigation";
+
+type Props = {
+  fileName: string;
+  activeTab: "breakdown" | "payments";
+};
+
+export function FileNavigation({ fileName, activeTab }: Props) {
+  const nav = useFileNavigation(fileName);
+
+  if (nav.status === "loading") {
+    return <h2 className="text-primary-content text-lg">{fileName}</h2>;
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {nav.hasPrev ? (
+        <Link
+          to="/payments/$fileName"
+          params={{ fileName: nav.prevFile! }}
+          search={{ tab: activeTab }}
+          className="btn btn-ghost btn-sm"
+        >
+          &larr; 前へ
+        </Link>
+      ) : (
+        <button type="button" className="btn btn-ghost btn-sm" disabled>
+          &larr; 前へ
+        </button>
+      )}
+
+      <h2 className="text-primary-content flex-1 text-center text-lg">
+        {fileName}
+      </h2>
+
+      {nav.hasNext ? (
+        <Link
+          to="/payments/$fileName"
+          params={{ fileName: nav.nextFile! }}
+          search={{ tab: activeTab }}
+          className="btn btn-ghost btn-sm"
+        >
+          次へ &rarr;
+        </Link>
+      ) : (
+        <button type="button" className="btn btn-ghost btn-sm" disabled>
+          次へ &rarr;
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/pages/DetailPage/components/Tabs.tsx
+++ b/src/pages/DetailPage/components/Tabs.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet } from "@tanstack/react-router";
 import clsx from "clsx";
+import { FileNavigation } from "./FileNavigation";
 import { TotalAmount } from "./TotalAmount";
 
 type Props = {
@@ -10,7 +11,7 @@ type Props = {
 export function Tabs({ fileName, activeTab }: Props) {
   return (
     <>
-      <h2 className="text-primary-content text-lg">{fileName}</h2>
+      <FileNavigation fileName={fileName} activeTab={activeTab} />
 
       <TotalAmount fileName={fileName} />
 

--- a/src/pages/DetailPage/hooks/useFileNavigation.test.ts
+++ b/src/pages/DetailPage/hooks/useFileNavigation.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useFileNavigation } from "./useFileNavigation";
+
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: vi.fn(),
+}));
+
+import { useLiveQuery } from "dexie-react-hooks";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("ローディング中はstatus=loadingを返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue(undefined);
+
+  const { result } = renderHook(() => useFileNavigation("test.csv"));
+
+  expect(result.current.status).toBe("loading");
+  expect(result.current.hasPrev).toBe(false);
+  expect(result.current.hasNext).toBe(false);
+});
+
+test("ファイル一覧がソートされる", () => {
+  vi.mocked(useLiveQuery).mockReturnValue([
+    { fileName: "202505.csv", payments: [] },
+    { fileName: "202503.csv", payments: [] },
+    { fileName: "202504.csv", payments: [] },
+  ]);
+
+  const { result } = renderHook(() => useFileNavigation("202504.csv"));
+
+  expect(result.current.files).toEqual([
+    "202503.csv",
+    "202504.csv",
+    "202505.csv",
+  ]);
+});
+
+test("中間のファイルでは前後両方に移動可能", () => {
+  vi.mocked(useLiveQuery).mockReturnValue([
+    { fileName: "202503.csv", payments: [] },
+    { fileName: "202504.csv", payments: [] },
+    { fileName: "202505.csv", payments: [] },
+  ]);
+
+  const { result } = renderHook(() => useFileNavigation("202504.csv"));
+
+  expect(result.current.status).toBe("ready");
+  expect(result.current.hasPrev).toBe(true);
+  expect(result.current.hasNext).toBe(true);
+  expect(result.current.prevFile).toBe("202503.csv");
+  expect(result.current.nextFile).toBe("202505.csv");
+});
+
+test("最初のファイルでは前へ移動不可", () => {
+  vi.mocked(useLiveQuery).mockReturnValue([
+    { fileName: "202503.csv", payments: [] },
+    { fileName: "202504.csv", payments: [] },
+  ]);
+
+  const { result } = renderHook(() => useFileNavigation("202503.csv"));
+
+  expect(result.current.hasPrev).toBe(false);
+  expect(result.current.hasNext).toBe(true);
+  expect(result.current.prevFile).toBeNull();
+});
+
+test("最後のファイルでは次へ移動不可", () => {
+  vi.mocked(useLiveQuery).mockReturnValue([
+    { fileName: "202503.csv", payments: [] },
+    { fileName: "202504.csv", payments: [] },
+  ]);
+
+  const { result } = renderHook(() => useFileNavigation("202504.csv"));
+
+  expect(result.current.hasPrev).toBe(true);
+  expect(result.current.hasNext).toBe(false);
+  expect(result.current.nextFile).toBeNull();
+});
+
+test("ファイルが1つだけの場合は前後どちらにも移動不可", () => {
+  vi.mocked(useLiveQuery).mockReturnValue([
+    { fileName: "202504.csv", payments: [] },
+  ]);
+
+  const { result } = renderHook(() => useFileNavigation("202504.csv"));
+
+  expect(result.current.hasPrev).toBe(false);
+  expect(result.current.hasNext).toBe(false);
+});

--- a/src/pages/DetailPage/hooks/useFileNavigation.ts
+++ b/src/pages/DetailPage/hooks/useFileNavigation.ts
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import { usePaymentsFiles } from "../../../data";
+
+type FileNavigationResult =
+  | {
+      status: "loading";
+      files: [];
+      currentIndex: -1;
+      prevFile: null;
+      nextFile: null;
+      hasPrev: false;
+      hasNext: false;
+    }
+  | {
+      status: "ready";
+      files: string[];
+      currentIndex: number;
+      prevFile: string | null;
+      nextFile: string | null;
+      hasPrev: boolean;
+      hasNext: boolean;
+    };
+
+export function useFileNavigation(
+  currentFileName: string,
+): FileNavigationResult {
+  const paymentFiles = usePaymentsFiles();
+
+  return useMemo(() => {
+    if (!paymentFiles) {
+      return {
+        status: "loading" as const,
+        files: [] as [],
+        currentIndex: -1 as const,
+        prevFile: null,
+        nextFile: null,
+        hasPrev: false as const,
+        hasNext: false as const,
+      };
+    }
+
+    const sortedFiles = [...paymentFiles]
+      .map((f) => f.fileName)
+      .sort((a, b) => a.localeCompare(b));
+
+    const currentIndex = sortedFiles.indexOf(currentFileName);
+    const prevFile = currentIndex > 0 ? sortedFiles[currentIndex - 1] : null;
+    const nextFile =
+      currentIndex < sortedFiles.length - 1
+        ? sortedFiles[currentIndex + 1]
+        : null;
+
+    return {
+      status: "ready" as const,
+      files: sortedFiles,
+      currentIndex,
+      prevFile,
+      nextFile,
+      hasPrev: prevFile !== null,
+      hasNext: nextFile !== null,
+    };
+  }, [paymentFiles, currentFileName]);
+}


### PR DESCRIPTION
## Summary
- 詳細ページ（`/payments/:fileName`）間で前後のファイルに移動できるナビゲーションを追加
- `[← 前へ]` `[次へ →]` ボタンで隣接するファイルへ移動可能
- 最初/最後のファイルの場合はボタンが無効化される

## 変更内容
- `useFileNavigation`フック: ファイル一覧から現在のファイルの前後を特定
- `FileNavigation`コンポーネント: 前へ/次へボタンのUI
- `Tabs.tsx`更新: ファイル名表示をナビゲーションに置き換え

## Test plan
- [ ] 複数ファイルをアップロードした状態で詳細ページを開く
- [ ] 「前へ」「次へ」ボタンで隣接ファイルに移動できることを確認
- [ ] 最初のファイルで「前へ」ボタンが無効化されていることを確認
- [ ] 最後のファイルで「次へ」ボタンが無効化されていることを確認
- [ ] タブ（内訳/支払い一覧）を切り替えた状態でファイル移動してもタブ状態が維持されることを確認

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)