### PR TITLE
useLiveQueryに依存配列を追加してページ遷移時のデータ更新を修正

### DIFF
--- a/src/data/payments/usePayments.ts
+++ b/src/data/payments/usePayments.ts
@@ -6,8 +6,9 @@ type Props = {
 };
 
 export function usePayments({ fileName }: Props) {
-  const files = useLiveQuery(() =>
-    db.paymentFiles.where("fileName").equals(fileName).toArray(),
+  const files = useLiveQuery(
+    () => db.paymentFiles.where("fileName").equals(fileName).toArray(),
+    [fileName],
   );
   const file = files ? files[0] : undefined;
 


### PR DESCRIPTION
## Summary
- `usePayments`フックの`useLiveQuery`に依存配列`[fileName]`を追加
- ファイルナビゲーション（#80）使用時にページ遷移してもデータが更新されない問題を修正

## 原因
`useLiveQuery`の第2引数（依存配列）が指定されていなかったため、クロージャ内の`fileName`が古い値のまま保持され、ページ遷移で`fileName`が変わっても新しいクエリが実行されなかった。

## Test plan
- [x] `npm run lint` - ESLintチェック
- [x] `npm run fmt:check` - フォーマットチェック
- [x] `npm test` - テスト実行
- [x] `npm run build` - ビルド確認
- [ ] 複数ファイルをアップロードした状態で「前へ」「次へ」ボタンで移動すると、データが正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)