### PR TITLE
Heroiconsを導入してテキストベースのアイコンを置き換え

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@heroicons/react": "^2.2.0",
         "@tailwindcss/vite": "4.1.12",
         "@tanstack/react-router": "1.131.17",
         "@tanstack/react-router-devtools": "1.131.17",
@@ -1511,6 +1512,15 @@
         "@exodus/crypto": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@heroicons/react": "^2.2.0",
     "@tailwindcss/vite": "4.1.12",
     "@tanstack/react-router": "1.131.17",
     "@tanstack/react-router-devtools": "1.131.17",

--- a/src/pages/DetailPage/components/FileNavigation.tsx
+++ b/src/pages/DetailPage/components/FileNavigation.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/24/outline";
 import { useFileNavigation } from "../hooks/useFileNavigation";
 
 type Props = {
@@ -22,11 +23,13 @@ export function FileNavigation({ fileName, activeTab }: Props) {
           search={{ tab: activeTab }}
           className="btn btn-ghost btn-sm"
         >
-          &larr; 前へ
+          <ArrowLeftIcon className="mr-1 inline h-4 w-4" />
+          前へ
         </Link>
       ) : (
         <button type="button" className="btn btn-ghost btn-sm" disabled>
-          &larr; 前へ
+          <ArrowLeftIcon className="mr-1 inline h-4 w-4" />
+          前へ
         </button>
       )}
 
@@ -41,11 +44,13 @@ export function FileNavigation({ fileName, activeTab }: Props) {
           search={{ tab: activeTab }}
           className="btn btn-ghost btn-sm"
         >
-          次へ &rarr;
+          次へ
+          <ArrowRightIcon className="ml-1 inline h-4 w-4" />
         </Link>
       ) : (
         <button type="button" className="btn btn-ghost btn-sm" disabled>
-          次へ &rarr;
+          次へ
+          <ArrowRightIcon className="ml-1 inline h-4 w-4" />
         </button>
       )}
     </div>

--- a/src/pages/DetailPage/components/PaymentTagView/TagBreakdownRow.tsx
+++ b/src/pages/DetailPage/components/PaymentTagView/TagBreakdownRow.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { ChevronRightIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
 import { PaymentDetailTable } from "./PaymentDetailTable";
 
 type PaymentDetail = {
@@ -37,7 +38,11 @@ export function TagBreakdownRow({ item, index }: Props) {
       >
         <td>
           <span className="text-base-content/60 mr-2">
-            {isExpanded ? "▼" : "▶"}
+            {isExpanded ? (
+              <ChevronDownIcon className="inline h-4 w-4" />
+            ) : (
+              <ChevronRightIcon className="inline h-4 w-4" />
+            )}
           </span>
           {item.tag ? (
             <span className="badge badge-primary">{item.tag.name}</span>

--- a/src/pages/RootPage.tsx
+++ b/src/pages/RootPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "../data/payments";
 import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 
 export function RootPage() {
   const files = usePaymentsFiles();
@@ -120,7 +121,7 @@ export function RootPage() {
                     onClick={() => void handleDeleteFile(file.fileName)}
                     type="button"
                   >
-                    ×
+                    <XMarkIcon className="h-4 w-4" />
                   </button>
                 </div>
               </li>

--- a/src/pages/SettingsPage/components/TagItem.tsx
+++ b/src/pages/SettingsPage/components/TagItem.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import {
+  ChevronRightIcon,
+  ChevronDownIcon,
+  Bars2Icon,
+} from "@heroicons/react/24/outline";
 import { type Tag } from "../../../data/db";
 import { updateTag } from "../../../data/tags/updateTag";
 import { deleteTag } from "../../../data/tags/deleteTag";
@@ -65,7 +70,7 @@ export function TagItem({ tag }: Props) {
           {...attributes}
           {...listeners}
         >
-          ⋮⋮
+          <Bars2Icon className="h-4 w-4" />
         </button>
 
         <button
@@ -73,7 +78,11 @@ export function TagItem({ tag }: Props) {
           className="btn btn-ghost btn-sm px-2"
           onClick={() => setIsExpanded(!isExpanded)}
         >
-          {isExpanded ? "▼" : "▶"}
+          {isExpanded ? (
+            <ChevronDownIcon className="h-4 w-4" />
+          ) : (
+            <ChevronRightIcon className="h-4 w-4" />
+          )}
         </button>
 
         {isEditing ? (

--- a/src/pages/SettingsPage/components/TagRuleItem.tsx
+++ b/src/pages/SettingsPage/components/TagRuleItem.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { Bars2Icon } from "@heroicons/react/24/outline";
 import { type TagRule } from "../../../data/db";
 import { updateTagRule } from "../../../data/tags/updateTagRule";
 import { deleteTagRule } from "../../../data/tags/deleteTagRule";
@@ -58,7 +59,7 @@ export function TagRuleItem({ rule }: Props) {
         {...attributes}
         {...listeners}
       >
-        ⋮⋮
+        <Bars2Icon className="h-4 w-4" />
       </button>
 
       {isEditing ? (


### PR DESCRIPTION
## Summary
- @heroicons/reactを導入し、テキスト文字で表現していたアイコンをSVGアイコンに置き換え
- 対象: ▶/▼（展開）、×（削除）、←/→（ナビゲーション）、⋮⋮（ドラッグハンドル）
- Tailwind Labs公式のアイコンライブラリでDaisyUIとの相性が良い

## Test plan
- [ ] 開発サーバーで各ページのアイコン表示を確認
- [ ] ファイル一覧ページの削除ボタン（×アイコン）
- [ ] 詳細ページのナビゲーション（←/→アイコン）
- [ ] タグ設定ページの展開・折りたたみ（▶/▼アイコン）
- [ ] ドラッグハンドル（⋮⋮アイコン）

🤖 Generated with [Claude Code](https://claude.com/claude-code)