### PR TITLE
feat: 初期ページに月別合計金額とグラフを追加

### DIFF
--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -62,5 +62,5 @@ db.version(3)
     );
   });
 
-export type { PaymentFile, Category, CategoryRule };
+export type { Payment, PaymentFile, Category, CategoryRule };
 export { db };

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,6 +1,6 @@
 // Re-export from db
 export { db } from "./db";
-export type { PaymentFile, Category, CategoryRule } from "./db";
+export type { Payment, PaymentFile, Category, CategoryRule } from "./db";
 
 // Re-export from payments
 export {

--- a/src/pages/RootPage.tsx
+++ b/src/pages/RootPage.tsx
@@ -9,6 +9,7 @@ import {
 import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { MonthlyTotalChart } from "./RootPage/components/MonthlyTotalChart";
 
 export function RootPage() {
   const files = usePaymentsFiles();
@@ -104,6 +105,13 @@ export function RootPage() {
         </div>
       </div>
 
+      {files && files.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <h2 className="text-primary-content text-lg">月別推移</h2>
+          <MonthlyTotalChart files={files} />
+        </div>
+      )}
+
       <div>
         <h2 className="text-primary-content text-lg">ファイル一覧</h2>
         {files && files.length > 0 ? (
@@ -116,7 +124,13 @@ export function RootPage() {
                     params={{ fileName: file.fileName }}
                     className="flex-1 text-left"
                   >
-                    {file.fileName}
+                    <span>{file.fileName}</span>
+                    <span className="text-base-content/60 ml-4">
+                      ¥
+                      {file.payments
+                        .reduce((acc, p) => acc + p.price, 0)
+                        .toLocaleString()}
+                    </span>
                   </Link>
                   <button
                     className="btn btn-sm text-base-content/40 hover:text-error hover:bg-error/5 ml-2 border-none bg-transparent"

--- a/src/pages/RootPage/components/MonthlyTotalChart.tsx
+++ b/src/pages/RootPage/components/MonthlyTotalChart.tsx
@@ -1,0 +1,47 @@
+import {
+  LineChart,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Line,
+} from "recharts";
+import type { PaymentFile } from "../../../data";
+
+type Props = {
+  files: PaymentFile[];
+};
+
+export function MonthlyTotalChart({ files }: Props) {
+  const chartData = files
+    .map((file) => ({
+      name: file.fileName,
+      value: file.payments.reduce((acc, p) => acc + p.price, 0),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  if (chartData.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="max-w-full">
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart width={1000} height={250} data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip formatter={(value) => [`¥${value.toLocaleString()}`]} />
+          <Line
+            type="monotone"
+            dataKey="value"
+            name="合計金額"
+            stroke="#8884d8"
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- ファイル一覧の各行に合計金額を表示
- ファイル一覧の上に月別推移の折れ線グラフを追加

## 変更内容
- `src/pages/RootPage.tsx`: ファイル一覧に金額表示とグラフコンポーネントを追加
- `src/pages/RootPage/components/MonthlyTotalChart.tsx`: 月別推移グラフコンポーネントを新規作成
- `src/data/db.ts`, `src/data/index.ts`: Payment型をexport

Closes #89

## Test plan
- [ ] 初期ページでファイル一覧に合計金額が表示されることを確認
- [ ] 複数ファイルがある場合、月別推移のグラフが表示されることを確認
- [ ] グラフのTooltipに金額が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)