### PR TITLE
feat: 円の表記を「123,456 円」形式に統一

### DIFF
--- a/src/pages/DetailPage/components/PaymentCategoryView/CategoryBreakdownRow.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/CategoryBreakdownRow.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ChevronRightIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
 import { PaymentDetailTable } from "./PaymentDetailTable";
+import { formatYen } from "../../../../utils/formatYen";
 
 type PaymentDetail = {
   name: string;
@@ -51,7 +52,7 @@ export function CategoryBreakdownRow({ item, index }: Props) {
           )}
         </td>
         <td>{item.count} 件</td>
-        <td>{item.total.toLocaleString()} 円</td>
+        <td>{formatYen(item.total)}</td>
       </tr>
 
       {isExpanded && (

--- a/src/pages/DetailPage/components/PaymentCategoryView/PaymentDetailTable.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PaymentDetailTable.tsx
@@ -1,3 +1,5 @@
+import { formatYen } from "../../../../utils/formatYen";
+
 type PaymentDetail = {
   name: string;
   date: string;
@@ -24,7 +26,7 @@ export function PaymentDetailTable({ payments }: Props) {
             <tr key={`${payment.date}-${payment.name}-${idx}`}>
               <td>{payment.date}</td>
               <td>{payment.name}</td>
-              <td>{payment.price.toLocaleString()} 円</td>
+              <td>{formatYen(payment.price)}</td>
             </tr>
           ))}
         </tbody>

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
@@ -7,6 +7,7 @@ import {
   Cell,
   ResponsiveContainer,
 } from "recharts";
+import { formatYen } from "../../../../utils/formatYen";
 
 type Props = {
   data: { name: string; value: number }[];
@@ -21,12 +22,7 @@ export function PayviewCategoryBarChart({ data }: Props) {
         <BarChart data={data}>
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip
-            formatter={(value: number) => [
-              `${value.toLocaleString()} 円`,
-              "金額",
-            ]}
-          />
+          <Tooltip formatter={(value: number) => [formatYen(value), "金額"]} />
           <Bar dataKey="value">
             {data.map((item, index) => (
               <Cell key={item.name} fill={COLORS[index % COLORS.length]} />

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryPieChart.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryPieChart.tsx
@@ -1,4 +1,5 @@
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
+import { formatYen } from "../../../../utils/formatYen";
 
 type Props = {
   data: { name: string; value: number }[];
@@ -30,7 +31,7 @@ export function PayviewCategoryPieChart({ data }: Props) {
               value: number,
               _name: string,
               props: { payload?: { name: string; value: number } },
-            ) => [`${value.toLocaleString()} 円`, props.payload?.name ?? ""]}
+            ) => [formatYen(value), props.payload?.name ?? ""]}
           />
         </PieChart>
       </ResponsiveContainer>

--- a/src/pages/DetailPage/components/PaymentView/PaymentView.tsx
+++ b/src/pages/DetailPage/components/PaymentView/PaymentView.tsx
@@ -1,5 +1,6 @@
 import { usePayments } from "../../../../data/payments";
 import { PayviewLineChart } from "./PayviewLineChart";
+import { formatYen } from "../../../../utils/formatYen";
 
 type Props = {
   fileName: string;
@@ -46,7 +47,7 @@ export function PaymentView({ fileName }: Props) {
                   <tr key={index}>
                     <td>{item.date}</td>
                     <td>{item.name}</td>
-                    <td>{item.price.toLocaleString()} 円</td>
+                    <td>{formatYen(item.price)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/src/pages/DetailPage/components/PaymentView/PayviewLineChart.tsx
+++ b/src/pages/DetailPage/components/PaymentView/PayviewLineChart.tsx
@@ -8,6 +8,7 @@ import {
   Legend,
   Line,
 } from "recharts";
+import { formatYen } from "../../../../utils/formatYen";
 
 type Props = {
   data: { name: string; value: number }[];
@@ -21,7 +22,7 @@ export function PayviewLineChart({ data }: Props) {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip formatter={(value) => [`${value.toLocaleString()} 円`]} />
+          <Tooltip formatter={(value) => [formatYen(value as number)]} />
           <Legend />
           <Line
             type="monotone"

--- a/src/pages/DetailPage/components/TotalAmount.tsx
+++ b/src/pages/DetailPage/components/TotalAmount.tsx
@@ -1,4 +1,5 @@
 import { usePayments } from "../../../data/payments";
+import { formatYen } from "../../../utils/formatYen";
 
 type Props = {
   fileName: string;
@@ -17,8 +18,6 @@ export function TotalAmount({ fileName }: Props) {
   );
 
   return (
-    <p className="text-secondary-content text-lg">
-      合計: {total.toLocaleString()} 円
-    </p>
+    <p className="text-secondary-content text-lg">合計: {formatYen(total)}</p>
   );
 }

--- a/src/pages/RootPage.tsx
+++ b/src/pages/RootPage.tsx
@@ -10,6 +10,7 @@ import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { MonthlyTotalChart } from "./RootPage/components/MonthlyTotalChart";
+import { formatYen } from "../utils/formatYen";
 
 export function RootPage() {
   const files = usePaymentsFiles();
@@ -126,10 +127,9 @@ export function RootPage() {
                   >
                     <span>{file.fileName}</span>
                     <span className="text-base-content/60 ml-4">
-                      ¥
-                      {file.payments
-                        .reduce((acc, p) => acc + p.price, 0)
-                        .toLocaleString()}
+                      {formatYen(
+                        file.payments.reduce((acc, p) => acc + p.price, 0),
+                      )}
                     </span>
                   </Link>
                   <button

--- a/src/pages/RootPage/components/MonthlyTotalChart.tsx
+++ b/src/pages/RootPage/components/MonthlyTotalChart.tsx
@@ -8,6 +8,7 @@ import {
   Line,
 } from "recharts";
 import type { PaymentFile } from "../../../data";
+import { formatYen } from "../../../utils/formatYen";
 
 type Props = {
   files: PaymentFile[];
@@ -32,7 +33,7 @@ export function MonthlyTotalChart({ files }: Props) {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip formatter={(value) => [`¥${value.toLocaleString()}`]} />
+          <Tooltip formatter={(value) => [formatYen(value as number)]} />
           <Line
             type="monotone"
             dataKey="value"

--- a/src/utils/formatYen.test.ts
+++ b/src/utils/formatYen.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { formatYen } from "./formatYen";
+
+test("正の整数を正しくフォーマットする", () => {
+  expect(formatYen(123456)).toBe("123,456 円");
+});
+
+test("0を正しくフォーマットする", () => {
+  expect(formatYen(0)).toBe("0 円");
+});
+
+test("小さい数値を正しくフォーマットする", () => {
+  expect(formatYen(100)).toBe("100 円");
+});
+
+test("大きい数値を正しくフォーマットする", () => {
+  expect(formatYen(1234567890)).toBe("1,234,567,890 円");
+});
+
+test("負の数値を正しくフォーマットする", () => {
+  expect(formatYen(-5000)).toBe("-5,000 円");
+});

--- a/src/utils/formatYen.ts
+++ b/src/utils/formatYen.ts
@@ -1,0 +1,8 @@
+/**
+ * 金額を「123,456 円」形式にフォーマットする
+ * @param amount - フォーマットする金額（数値）
+ * @returns フォーマット済み文字列（例: "123,456 円"）
+ */
+export function formatYen(amount: number): string {
+  return `${amount.toLocaleString()} 円`;
+}


### PR DESCRIPTION
## Summary
- `formatYen`関数を追加して金額フォーマットを一元化
- RootPage/DetailPageの全ての金額表示を統一（¥記号から「円」に変更）
- テストを追加

## Test plan
- [x] `npm run fmt:check` 通過
- [x] `npm run lint` 通過（既存のwarningのみ）
- [x] `npm test` 通過（81テスト、formatYenのテスト5件を含む）
- [x] `npm run build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)