### PR TITLE
fix: 配列インデックスをkeyとして使用している箇所を修正

### DIFF
--- a/src/pages/DetailPage/components/PaymentCategoryView/PaymentDetailTable.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PaymentDetailTable.tsx
@@ -22,8 +22,8 @@ export function PaymentDetailTable({ payments }: Props) {
           </tr>
         </thead>
         <tbody>
-          {payments.map((payment, idx) => (
-            <tr key={`${payment.date}-${payment.name}-${idx}`}>
+          {payments.map((payment) => (
+            <tr key={`${payment.date}-${payment.name}-${payment.price}`}>
               <td>{payment.date}</td>
               <td>{payment.name}</td>
               <td>{formatYen(payment.price)}</td>

--- a/src/pages/DetailPage/components/PaymentView/PaymentView.tsx
+++ b/src/pages/DetailPage/components/PaymentView/PaymentView.tsx
@@ -43,8 +43,8 @@ export function PaymentView({ fileName }: Props) {
                 </tr>
               </thead>
               <tbody>
-                {payments.payments.map((item, index) => (
-                  <tr key={index}>
+                {payments.payments.map((item) => (
+                  <tr key={`${item.date}-${item.name}-${item.price}`}>
                     <td>{item.date}</td>
                     <td>{item.name}</td>
                     <td>{formatYen(item.price)}</td>

--- a/src/pages/RootPage.tsx
+++ b/src/pages/RootPage.tsx
@@ -117,8 +117,8 @@ export function RootPage() {
         <h2 className="text-primary-content text-lg">ファイル一覧</h2>
         {files && files.length > 0 ? (
           <ul className="menu bg-base-200 rounded-box w-full">
-            {files.map((file, index) => (
-              <li key={index}>
+            {files.map((file) => (
+              <li key={file.fileName}>
                 <div className="flex w-full items-center justify-between">
                   <Link
                     to="/payments/$fileName"


### PR DESCRIPTION
## Summary
- react-x/no-array-index-key の ESLint 警告を解消
- 配列のインデックスではなく一意の値を key として使用するよう修正
- RootPage: `file.fileName` を使用
- PaymentView / PaymentDetailTable: `date-name-price` の複合キーを使用

## Test plan
- [ ] `npm run lint` で警告がないことを確認
- [ ] `npm run fmt:check` がパスすることを確認
- [ ] `npm test` がパスすることを確認
- [ ] `npm run build` がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)