### PR TITLE
refactor: RootPageのファイル配置を他ページと統一

### DIFF
--- a/src/pages/RootPage/RootPage.tsx
+++ b/src/pages/RootPage/RootPage.tsx
@@ -5,12 +5,12 @@ import {
   AddPaymentsInvalidFileError,
   usePaymentsFiles,
   deletePaymentFile,
-} from "../data/payments";
+} from "../../data/payments";
 import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
 import { XMarkIcon } from "@heroicons/react/24/outline";
-import { MonthlyTotalChart } from "./RootPage/components/MonthlyTotalChart";
-import { formatYen } from "../utils/formatYen";
+import { MonthlyTotalChart } from "./components/MonthlyTotalChart";
+import { formatYen } from "../../utils/formatYen";
 
 export function RootPage() {
   const files = usePaymentsFiles();

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { RootPage } from "../pages/RootPage";
+import { RootPage } from "../pages/RootPage/RootPage";
 
 export const Route = createFileRoute("/")({
   component: RootPage,


### PR DESCRIPTION
## Summary
- RootPage.tsx を RootPage/RootPage.tsx に移動
- DetailPage, SettingsPage と同じディレクトリ構造に統一

## Test plan
- [x] ビルド成功
- [x] lint/format チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)