### PR TITLE
fix: カテゴリルール保存時の.trim()を削除

### DIFF
--- a/src/data/payments/usePaymentsByCategory.test.ts
+++ b/src/data/payments/usePaymentsByCategory.test.ts
@@ -298,6 +298,55 @@ test("正常系: カテゴリはあるがルールがない場合、全て未分
   }
 });
 
+test("正常系: スペースを含むパターンで支払い名にマッチする", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      { date: "2023-01-01", name: "AMAZON CO JP", price: 3000, count: 1 },
+      { date: "2023-01-02", name: "AMAZONPRIME", price: 500, count: 1 },
+    ],
+  });
+  vi.mocked(useAllCategoryRules).mockReturnValue({
+    status: "completed",
+    categoriesWithRules: [
+      {
+        id: "category-1",
+        name: "ショッピング",
+        order: 0,
+        rules: [
+          {
+            id: "rule-1",
+            categoryId: "category-1",
+            pattern: "AMAZON CO",
+            order: 0,
+          },
+        ],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByCategory({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    // "AMAZON CO" (スペース含む) は "AMAZON CO JP" にマッチするが "AMAZONPRIME" にはマッチしない
+    expect(result.current.breakdown).toHaveLength(2);
+    const categorized = result.current.breakdown.find(
+      (b) => b.category !== null,
+    );
+    const uncategorized = result.current.breakdown.find(
+      (b) => b.category === null,
+    );
+    expect(categorized?.category?.name).toBe("ショッピング");
+    expect(categorized?.total).toBe(3000);
+    expect(categorized?.count).toBe(1);
+    expect(uncategorized?.name).toBe("AMAZONPRIME");
+    expect(uncategorized?.total).toBe(500);
+  }
+});
+
 test("正常系: 支払いがない場合、空のbreakdownを返す", () => {
   vi.mocked(usePayments).mockReturnValue({
     status: "completed",

--- a/src/pages/SettingsPage/components/AddCategoryRuleForm.tsx
+++ b/src/pages/SettingsPage/components/AddCategoryRuleForm.tsx
@@ -16,7 +16,7 @@ export function AddCategoryRuleForm({ categoryId }: Props) {
     try {
       await addCategoryRule({
         categoryId,
-        pattern: pattern.trim(),
+        pattern,
       });
       setPattern("");
     } catch {

--- a/src/pages/SettingsPage/components/CategoryRuleItem.tsx
+++ b/src/pages/SettingsPage/components/CategoryRuleItem.tsx
@@ -28,7 +28,7 @@ export function CategoryRuleItem({ rule }: Props) {
     try {
       await updateCategoryRule({
         id: rule.id,
-        pattern: editPattern.trim(),
+        pattern: editPattern,
       });
       setIsEditing(false);
     } catch {


### PR DESCRIPTION
close #114

## 概要

カテゴリルール保存時に `.trim()` でスペースが除去されていたため、スペースを含むパターンでのマッチングが意図通り動作しない問題を修正。

## 変更内容

- `AddCategoryRuleForm.tsx`: ルール追加時の `pattern.trim()` を削除し、入力値をそのまま保存
- `CategoryRuleItem.tsx`: ルール編集時の `editPattern.trim()` を削除し、入力値をそのまま保存
- `usePaymentsByCategory.test.ts`: スペースを含むパターンでのマッチングテストを追加

空白のみのルール登録を防ぐバリデーション（`if (!pattern.trim()) return`）は維持。

## Test plan

- [x] `npm test` 全101テスト通過
- [x] `npm run lint` 通過
- [x] `npm run fmt:check` 通過
- [x] `npm run build` 通過
- [x] スペースを含むパターンのテストケース追加・通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)