### PR TITLE
fix: カテゴリルールのマッチングで全角/半角スペースを正規化して比較

### DIFF
--- a/src/data/payments/usePaymentsByCategory.test.ts
+++ b/src/data/payments/usePaymentsByCategory.test.ts
@@ -361,6 +361,86 @@ test("正常系: スペースを含むパターンで支払い名にマッチす
   }
 });
 
+test("正常系: 全角スペースと半角スペースが正規化されてマッチする", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      // 半角スペース×2
+      { date: "2023-01-01", name: "ＡＢＣＤ  ＳＨＯＰ", price: 3000, count: 1 },
+    ],
+  });
+  vi.mocked(useAllCategoryRules).mockReturnValue({
+    status: "completed",
+    categoriesWithRules: [
+      {
+        id: "category-1",
+        name: "ショッピング",
+        order: 0,
+        rules: [
+          {
+            id: "rule-1",
+            categoryId: "category-1",
+            // 全角スペース×1
+            pattern: "ＡＢＣＤ\u3000ＳＨＯＰ",
+            order: 0,
+          },
+        ],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByCategory({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.breakdown).toHaveLength(1);
+    expect(result.current.breakdown[0].category?.name).toBe("ショッピング");
+    expect(result.current.breakdown[0].total).toBe(3000);
+  }
+});
+
+test("正常系: 連続する半角スペースが正規化されてマッチする", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      // 半角スペース×3
+      { date: "2023-01-01", name: "SHOP   NAME", price: 2000, count: 1 },
+    ],
+  });
+  vi.mocked(useAllCategoryRules).mockReturnValue({
+    status: "completed",
+    categoriesWithRules: [
+      {
+        id: "category-1",
+        name: "ショッピング",
+        order: 0,
+        rules: [
+          {
+            id: "rule-1",
+            categoryId: "category-1",
+            // 半角スペース×1
+            pattern: "SHOP NAME",
+            order: 0,
+          },
+        ],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByCategory({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.breakdown).toHaveLength(1);
+    expect(result.current.breakdown[0].category?.name).toBe("ショッピング");
+    expect(result.current.breakdown[0].total).toBe(2000);
+  }
+});
+
 test("正常系: 支払いがない場合、空のbreakdownを返す", () => {
   vi.mocked(usePayments).mockReturnValue({
     status: "completed",

--- a/src/data/payments/usePaymentsByCategory.ts
+++ b/src/data/payments/usePaymentsByCategory.ts
@@ -37,6 +37,10 @@ type UsePaymentsByCategoryResult =
   | { status: "loading" }
   | { status: "completed"; breakdown: CategoryBreakdownItem[] };
 
+function normalizeSpaces(s: string): string {
+  return s.replace(/[\u3000]/g, " ").replace(/\s+/g, " ");
+}
+
 export function usePaymentsByCategory({
   fileName,
 }: Props): UsePaymentsByCategoryResult {
@@ -56,7 +60,9 @@ export function usePaymentsByCategory({
     const findCategoryForPayment = (paymentName: string): CategoryInfo => {
       for (const category of categoriesWithRules) {
         for (const rule of category.rules) {
-          if (paymentName.includes(rule.pattern)) {
+          if (
+            normalizeSpaces(paymentName).includes(normalizeSpaces(rule.pattern))
+          ) {
             return { id: category.id, name: category.name };
           }
         }


### PR DESCRIPTION
close #120

## 概要

カテゴリルールのパターンマッチングで、全角スペース（U+3000）と半角スペース（U+0020）が区別されてしまい、見た目が同じでもマッチしない問題を修正。

## 変更内容

- `normalizeSpaces` 関数を追加し、全角スペースを半角に変換 + 連続する空白を1つに正規化
- `findCategoryForPayment` で支払い名とルールパターンの両方を正規化してから `includes()` で比較
- 全角/半角スペースの正規化と連続スペースの正規化に関するテストを2件追加

## テスト計画

- [x] 全角スペースと半角スペースが正規化されてマッチすることを確認
- [x] 連続する半角スペースが正規化されてマッチすることを確認
- [x] 既存テスト（12件）が全て通過することを確認
- [x] lint / fmt / build が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)