### PR TITLE
feat: カテゴリ別内訳で未分類を常に最終行に固定表示

### DIFF
--- a/src/data/payments/usePaymentsByCategory.test.ts
+++ b/src/data/payments/usePaymentsByCategory.test.ts
@@ -361,6 +361,60 @@ test("正常系: スペースを含むパターンで支払い名にマッチす
   }
 });
 
+test("正常系: 未分類は金額に関わらず常にbreakdownの最終行に表示される", () => {
+  vi.mocked(usePayments).mockReturnValue({
+    status: "completed",
+    payments: [
+      { date: "2023-01-01", name: "スーパー", price: 500, count: 1 },
+      { date: "2023-01-02", name: "電車", price: 300, count: 1 },
+      { date: "2023-01-03", name: "謎の支払い", price: 10000, count: 1 },
+    ],
+  });
+  vi.mocked(useAllCategoryRules).mockReturnValue({
+    status: "completed",
+    categoriesWithRules: [
+      {
+        id: "category-1",
+        name: "食費",
+        order: 0,
+        rules: [
+          {
+            id: "rule-1",
+            categoryId: "category-1",
+            pattern: "スーパー",
+            order: 0,
+          },
+        ],
+      },
+      {
+        id: "category-2",
+        name: "交通費",
+        order: 1,
+        rules: [
+          { id: "rule-2", categoryId: "category-2", pattern: "電車", order: 0 },
+        ],
+      },
+    ],
+  });
+
+  const { result } = renderHook(() =>
+    usePaymentsByCategory({ fileName: "test.csv" }),
+  );
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.breakdown).toHaveLength(3);
+    // 分類済みカテゴリは金額降順
+    expect(result.current.breakdown[0].category?.name).toBe("食費");
+    expect(result.current.breakdown[0].total).toBe(500);
+    expect(result.current.breakdown[1].category?.name).toBe("交通費");
+    expect(result.current.breakdown[1].total).toBe(300);
+    // 未分類は金額が最大でも最終行
+    expect(result.current.breakdown[2].category).toBeNull();
+    expect(result.current.breakdown[2].total).toBe(10000);
+  }
+});
+
 test("正常系: 支払いがない場合、空のbreakdownを返す", () => {
   vi.mocked(usePayments).mockReturnValue({
     status: "completed",

--- a/src/data/payments/usePaymentsByCategory.ts
+++ b/src/data/payments/usePaymentsByCategory.ts
@@ -121,6 +121,8 @@ export function usePaymentsByCategory({
 
     const allBreakdown: CategoryBreakdownItem[] = [...categorizedBreakdown];
 
+    allBreakdown.sort((a, b) => b.total - a.total);
+
     if (uncategorizedTotals.size > 0) {
       const subBreakdown: SubBreakdownItem[] = Array.from(
         uncategorizedTotals.entries(),
@@ -140,8 +142,6 @@ export function usePaymentsByCategory({
         subBreakdown,
       });
     }
-
-    allBreakdown.sort((a, b) => b.total - a.total);
 
     return {
       status: "completed" as const,


### PR DESCRIPTION
close #122

## Summary

- カテゴリ別内訳テーブル・グラフで、未分類（`category: null`）が金額に関わらず常に最終行に表示されるようにした
- 分類済みカテゴリのみを金額降順でソートし、未分類はソート後に末尾に追加する方式に変更
- 未分類が最大金額でも末尾に固定されることを検証するテストを追加

## 変更内容

- `src/data/payments/usePaymentsByCategory.ts`: `allBreakdown.sort()` を未分類 push の前に移動
- `src/data/payments/usePaymentsByCategory.test.ts`: 未分類の末尾固定を検証するテストケースを追加

## Test plan

- [x] 既存テスト全11件が通過
- [x] 未分類が金額最大でも最終行に表示されるテストが通過
- [x] `npm run fmt:check` / `npm run lint` / `npm run build` 全て通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)