### PR TITLE
feat: カテゴリ別年予算と年間フィードバック表示の追加

### DIFF
--- a/src/data/categories/updateCategory.test.ts
+++ b/src/data/categories/updateCategory.test.ts
@@ -4,7 +4,8 @@ import { updateCategory } from "./updateCategory";
 vi.mock("../db", () => ({
   db: {
     categories: {
-      update: vi.fn(),
+      get: vi.fn(),
+      put: vi.fn(),
     },
   },
 }));
@@ -16,17 +17,95 @@ beforeEach(() => {
 });
 
 test("正常系: カテゴリ名が更新される", async () => {
-  vi.mocked(db.categories.update).mockResolvedValue(1 as never);
+  vi.mocked(db.categories.get).mockResolvedValue({
+    id: "category-1",
+    name: "旧名前",
+    order: 0,
+  } as never);
+  vi.mocked(db.categories.put).mockResolvedValue("category-1" as never);
 
   await updateCategory({ id: "category-1", name: "新しい名前" });
 
-  expect(db.categories.update).toHaveBeenCalledWith("category-1", {
+  expect(db.categories.put).toHaveBeenCalledWith({
+    id: "category-1",
     name: "新しい名前",
+    order: 0,
   });
 });
 
+test("正常系: 年予算が設定される", async () => {
+  vi.mocked(db.categories.get).mockResolvedValue({
+    id: "category-1",
+    name: "食費",
+    order: 0,
+  } as never);
+  vi.mocked(db.categories.put).mockResolvedValue("category-1" as never);
+
+  await updateCategory({
+    id: "category-1",
+    name: "食費",
+    annualBudget: 120000,
+  });
+
+  expect(db.categories.put).toHaveBeenCalledWith({
+    id: "category-1",
+    name: "食費",
+    order: 0,
+    annualBudget: 120000,
+  });
+});
+
+test("正常系: 年予算が削除される（undefinedを渡す）", async () => {
+  vi.mocked(db.categories.get).mockResolvedValue({
+    id: "category-1",
+    name: "食費",
+    order: 0,
+    annualBudget: 120000,
+  } as never);
+  vi.mocked(db.categories.put).mockResolvedValue("category-1" as never);
+
+  await updateCategory({ id: "category-1", name: "食費" });
+
+  expect(db.categories.put).toHaveBeenCalledWith({
+    id: "category-1",
+    name: "食費",
+    order: 0,
+  });
+});
+
+test("正常系: 既存の年予算が別の値に更新される", async () => {
+  vi.mocked(db.categories.get).mockResolvedValue({
+    id: "category-1",
+    name: "食費",
+    order: 0,
+    annualBudget: 60000,
+  } as never);
+  vi.mocked(db.categories.put).mockResolvedValue("category-1" as never);
+
+  await updateCategory({
+    id: "category-1",
+    name: "食費",
+    annualBudget: 120000,
+  });
+
+  expect(db.categories.put).toHaveBeenCalledWith({
+    id: "category-1",
+    name: "食費",
+    order: 0,
+    annualBudget: 120000,
+  });
+});
+
+test("正常系: カテゴリが存在しない場合は何もしない", async () => {
+  vi.mocked(db.categories.get).mockResolvedValue(undefined as never);
+
+  await updateCategory({ id: "not-exist", name: "名前" });
+
+  expect(db.categories.put).not.toHaveBeenCalled();
+});
+
 test("異常系: DB操作でエラーが発生した場合", async () => {
-  vi.mocked(db.categories.update).mockRejectedValue(
+  vi.mocked(db.categories.get).mockRejectedValue(
     new Error("DB Error") as never,
   );
 

--- a/src/data/categories/updateCategory.ts
+++ b/src/data/categories/updateCategory.ts
@@ -1,7 +1,19 @@
-import { db } from "../db";
+import { db, type Category } from "../db";
 
-type Input = { id: string; name: string };
+type Input = { id: string; name: string; annualBudget?: number };
 
 export async function updateCategory(input: Input): Promise<void> {
-  await db.categories.update(input.id, { name: input.name });
+  const { id, name, annualBudget } = input;
+
+  const existing = await db.categories.get(id);
+  if (!existing) return;
+
+  const updated: Category = {
+    id: existing.id,
+    name,
+    order: existing.order,
+    ...(annualBudget !== undefined ? { annualBudget } : {}),
+  };
+
+  await db.categories.put(updated);
 }

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -16,6 +16,7 @@ interface Category {
   id: string;
   name: string;
   order: number;
+  annualBudget?: number;
 }
 
 interface CategoryRule {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -7,6 +7,7 @@ export {
   usePayments,
   usePaymentsFiles,
   usePaymentsByCategory,
+  useAnnualBudgetSummary,
   deletePaymentFile,
   addPayments,
   AddPaymentsConstraintError,

--- a/src/data/payments/index.ts
+++ b/src/data/payments/index.ts
@@ -1,6 +1,7 @@
 export { usePayments } from "./usePayments";
 export { usePaymentsFiles } from "./usePaymentsFiles";
 export { usePaymentsByCategory } from "./usePaymentsByCategory";
+export { useAnnualBudgetSummary } from "./useAnnualBudgetSummary";
 export { deletePaymentFile } from "./deletePaymentFile";
 export {
   addPayments,

--- a/src/data/payments/useAnnualBudgetSummary.test.ts
+++ b/src/data/payments/useAnnualBudgetSummary.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAnnualBudgetSummary } from "./useAnnualBudgetSummary";
+
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: vi.fn(),
+}));
+
+import { useLiveQuery } from "dexie-react-hooks";
+
+const CURRENT_YEAR = new Date().getFullYear().toString();
+
+function makeDate(year: string, month: string, day = "01") {
+  return `${year}-${month}-${day}`;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("正常系: データがロード中はstatus=loadingを返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue(undefined);
+
+  const { result } = renderHook(() => useAnnualBudgetSummary());
+
+  expect(result.current.status).toBe("loading");
+});
+
+test("正常系: 年予算が設定されたカテゴリは設定値とcurrentYearTotalを返す", () => {
+  vi.mocked(useLiveQuery).mockReturnValue({
+    paymentFiles: [
+      {
+        fileName: "test.csv",
+        payments: [
+          {
+            name: "スーパー",
+            date: makeDate(CURRENT_YEAR, "01"),
+            price: 5000,
+            count: 1,
+          },
+          {
+            name: "スーパー",
+            date: makeDate(CURRENT_YEAR, "02"),
+            price: 3000,
+            count: 1,
+          },
+        ],
+      },
+    ],
+    categories: [{ id: "cat-1", name: "食費", order: 0, annualBudget: 120000 }],
+    allRules: [
+      { id: "rule-1", categoryId: "cat-1", pattern: "スーパー", order: 0 },
+    ],
+  });
+
+  const { result } = renderHook(() => useAnnualBudgetSummary());
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.items).toHaveLength(1);
+    const item = result.current.items[0];
+    expect(item.categoryName).toBe("食費");
+    expect(item.annualBudget).toBe(120000);
+    expect(item.isFallback).toBe(false);
+    expect(item.currentYearTotal).toBe(8000);
+    expect(item.remaining).toBe(112000);
+  }
+});
+
+test("正常系: 年予算未設定の場合、月平均×12がフォールバックとして使われる", () => {
+  vi.mocked(useLiveQuery).mockReturnValue({
+    paymentFiles: [
+      {
+        fileName: "test.csv",
+        payments: [
+          // 2ヶ月分: 1月3000円、2月5000円 → 合計8000円 / 2ヶ月 * 12 = 48000円
+          {
+            name: "電車代",
+            date: makeDate(CURRENT_YEAR, "01"),
+            price: 3000,
+            count: 1,
+          },
+          {
+            name: "電車代",
+            date: makeDate(CURRENT_YEAR, "02"),
+            price: 5000,
+            count: 1,
+          },
+        ],
+      },
+    ],
+    categories: [{ id: "cat-1", name: "交通費", order: 0 }],
+    allRules: [
+      { id: "rule-1", categoryId: "cat-1", pattern: "電車", order: 0 },
+    ],
+  });
+
+  const { result } = renderHook(() => useAnnualBudgetSummary());
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.items).toHaveLength(1);
+    const item = result.current.items[0];
+    expect(item.isFallback).toBe(true);
+    expect(item.annualBudget).toBe(48000);
+    expect(item.currentYearTotal).toBe(8000);
+  }
+});
+
+test("正常系: 今年の支出のみcurrentYearTotalに集計される", () => {
+  const lastYear = String(Number(CURRENT_YEAR) - 1);
+
+  vi.mocked(useLiveQuery).mockReturnValue({
+    paymentFiles: [
+      {
+        fileName: "file1.csv",
+        payments: [
+          {
+            name: "映画",
+            date: makeDate(CURRENT_YEAR, "03"),
+            price: 10000,
+            count: 1,
+          },
+        ],
+      },
+      {
+        fileName: "file2.csv",
+        payments: [
+          {
+            name: "映画",
+            date: makeDate(lastYear, "06"),
+            price: 30000,
+            count: 1,
+          },
+        ],
+      },
+    ],
+    categories: [
+      { id: "cat-1", name: "娯楽費", order: 0, annualBudget: 200000 },
+    ],
+    allRules: [
+      { id: "rule-1", categoryId: "cat-1", pattern: "映画", order: 0 },
+    ],
+  });
+
+  const { result } = renderHook(() => useAnnualBudgetSummary());
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    const item = result.current.items[0];
+    expect(item.currentYearTotal).toBe(10000);
+    expect(item.remaining).toBe(190000);
+  }
+});
+
+test("正常系: 支出なし・年予算なしのカテゴリは結果に含まれない", () => {
+  vi.mocked(useLiveQuery).mockReturnValue({
+    paymentFiles: [
+      {
+        fileName: "test.csv",
+        payments: [
+          {
+            name: "スーパー",
+            date: makeDate(CURRENT_YEAR, "01"),
+            price: 5000,
+            count: 1,
+          },
+        ],
+      },
+    ],
+    categories: [
+      { id: "cat-1", name: "食費", order: 0, annualBudget: 120000 },
+      { id: "cat-2", name: "未使用カテゴリ", order: 1 },
+    ],
+    allRules: [
+      { id: "rule-1", categoryId: "cat-1", pattern: "スーパー", order: 0 },
+    ],
+  });
+
+  const { result } = renderHook(() => useAnnualBudgetSummary());
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].categoryName).toBe("食費");
+  }
+});
+
+test("正常系: 支出が年予算を超えた場合、remainingが負になる", () => {
+  vi.mocked(useLiveQuery).mockReturnValue({
+    paymentFiles: [
+      {
+        fileName: "test.csv",
+        payments: [
+          {
+            name: "旅行",
+            date: makeDate(CURRENT_YEAR, "05"),
+            price: 80000,
+            count: 1,
+          },
+        ],
+      },
+    ],
+    categories: [
+      { id: "cat-1", name: "旅行費", order: 0, annualBudget: 50000 },
+    ],
+    allRules: [
+      { id: "rule-1", categoryId: "cat-1", pattern: "旅行", order: 0 },
+    ],
+  });
+
+  const { result } = renderHook(() => useAnnualBudgetSummary());
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    const item = result.current.items[0];
+    expect(item.currentYearTotal).toBe(80000);
+    expect(item.remaining).toBe(-30000);
+  }
+});
+
+test("正常系: 月単位ではみ出ていても年累計ベースで正しく計算される", () => {
+  vi.mocked(useLiveQuery).mockReturnValue({
+    paymentFiles: [
+      {
+        fileName: "test.csv",
+        payments: [
+          // 1月は月予算（1万円）を超えているが、年間では余裕あり
+          {
+            name: "ライブ",
+            date: makeDate(CURRENT_YEAR, "01"),
+            price: 30000,
+            count: 1,
+          },
+          {
+            name: "ライブ",
+            date: makeDate(CURRENT_YEAR, "02"),
+            price: 5000,
+            count: 1,
+          },
+        ],
+      },
+    ],
+    categories: [
+      { id: "cat-1", name: "娯楽費", order: 0, annualBudget: 120000 },
+    ],
+    allRules: [
+      { id: "rule-1", categoryId: "cat-1", pattern: "ライブ", order: 0 },
+    ],
+  });
+
+  const { result } = renderHook(() => useAnnualBudgetSummary());
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    const item = result.current.items[0];
+    expect(item.currentYearTotal).toBe(35000);
+    expect(item.remaining).toBe(85000);
+  }
+});
+
+test("正常系: 年予算あり・今年の支出ゼロのカテゴリも表示される", () => {
+  vi.mocked(useLiveQuery).mockReturnValue({
+    paymentFiles: [],
+    categories: [
+      { id: "cat-1", name: "貯蓄目標", order: 0, annualBudget: 500000 },
+    ],
+    allRules: [],
+  });
+
+  const { result } = renderHook(() => useAnnualBudgetSummary());
+
+  expect(result.current.status).toBe("completed");
+  if (result.current.status === "completed") {
+    expect(result.current.items).toHaveLength(1);
+    const item = result.current.items[0];
+    expect(item.currentYearTotal).toBe(0);
+    expect(item.remaining).toBe(500000);
+    expect(item.isFallback).toBe(false);
+  }
+});

--- a/src/data/payments/useAnnualBudgetSummary.ts
+++ b/src/data/payments/useAnnualBudgetSummary.ts
@@ -1,0 +1,118 @@
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "../db";
+
+type AnnualBudgetSummaryItem = {
+  categoryId: string;
+  categoryName: string;
+  annualBudget: number;
+  isFallback: boolean;
+  currentYearTotal: number;
+  remaining: number;
+};
+
+type UseAnnualBudgetSummaryResult =
+  | { status: "loading" }
+  | { status: "completed"; items: AnnualBudgetSummaryItem[] };
+
+function normalizeSpaces(s: string): string {
+  return s.replace(/\u3000/g, " ").replace(/\s+/g, " ");
+}
+
+export function useAnnualBudgetSummary(): UseAnnualBudgetSummaryResult {
+  const data = useLiveQuery(async () => {
+    const paymentFiles = await db.paymentFiles.toArray();
+    const categories = await db.categories.orderBy("order").toArray();
+    const allRules = await db.categoryRules.toArray();
+    return { paymentFiles, categories, allRules };
+  });
+
+  return useMemo(() => {
+    if (!data) return { status: "loading" as const };
+
+    const { paymentFiles, categories, allRules } = data;
+    const currentYear = new Date().getFullYear().toString();
+
+    const categoryRulesMap = new Map<string, string[]>();
+    for (const rule of allRules) {
+      const patterns = categoryRulesMap.get(rule.categoryId) ?? [];
+      patterns.push(rule.pattern);
+      categoryRulesMap.set(rule.categoryId, patterns);
+    }
+
+    const findCategoryId = (paymentName: string): string | null => {
+      for (const category of categories) {
+        const patterns = categoryRulesMap.get(category.id) ?? [];
+        for (const pattern of patterns) {
+          if (normalizeSpaces(paymentName).includes(normalizeSpaces(pattern))) {
+            return category.id;
+          }
+        }
+      }
+      return null;
+    };
+
+    const categoryStats = new Map<
+      string,
+      { currentYearTotal: number; allTimeTotal: number; months: Set<string> }
+    >();
+
+    for (const file of paymentFiles) {
+      for (const payment of file.payments) {
+        const categoryId = findCategoryId(payment.name);
+        if (!categoryId) continue;
+
+        const stats = categoryStats.get(categoryId) ?? {
+          currentYearTotal: 0,
+          allTimeTotal: 0,
+          months: new Set<string>(),
+        };
+
+        stats.allTimeTotal += payment.price;
+        stats.months.add(payment.date.substring(0, 7));
+
+        if (payment.date.startsWith(currentYear)) {
+          stats.currentYearTotal += payment.price;
+        }
+
+        categoryStats.set(categoryId, stats);
+      }
+    }
+
+    const items: AnnualBudgetSummaryItem[] = [];
+
+    for (const category of categories) {
+      const stats = categoryStats.get(category.id);
+      const hasAnnualBudget = category.annualBudget !== undefined;
+      const hasSpending = stats !== undefined;
+
+      if (!hasAnnualBudget && !hasSpending) continue;
+
+      const currentYearTotal = stats?.currentYearTotal ?? 0;
+      let annualBudget: number;
+      let isFallback: boolean;
+
+      if (hasAnnualBudget) {
+        annualBudget = category.annualBudget!;
+        isFallback = false;
+      } else if (stats && stats.months.size > 0) {
+        const monthlyAvg = stats.allTimeTotal / stats.months.size;
+        annualBudget = Math.round(monthlyAvg * 12);
+        isFallback = true;
+      } else {
+        continue;
+      }
+
+      items.push({
+        categoryId: category.id,
+        categoryName: category.name,
+        annualBudget,
+        isFallback,
+        currentYearTotal,
+        remaining: annualBudget - currentYearTotal,
+      });
+    }
+
+    return { status: "completed" as const, items };
+  }, [data]);
+}

--- a/src/pages/RootPage/RootPage.tsx
+++ b/src/pages/RootPage/RootPage.tsx
@@ -108,21 +108,19 @@ export function RootPage() {
       </div>
 
       {files && files.length > 0 && (
-        <>
-          <div className="flex flex-col gap-2">
-            <h2 className="text-primary-content text-lg">月別推移</h2>
-            <MonthlyTotalChart files={files} />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <h2 className="text-primary-content text-lg">年間予算</h2>
-            <p className="text-info text-sm">
-              年予算は設定ページから各カテゴリに設定できます。未設定のカテゴリは過去データの月平均×12を暫定値として表示します。
-            </p>
-            <AnnualBudgetSummary />
-          </div>
-        </>
+        <div className="flex flex-col gap-2">
+          <h2 className="text-primary-content text-lg">月別推移</h2>
+          <MonthlyTotalChart files={files} />
+        </div>
       )}
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-primary-content text-lg">年間予算</h2>
+        <p className="text-info text-sm">
+          年予算は設定ページから各カテゴリに設定できます。未設定のカテゴリは過去データの月平均×12を暫定値として表示します。
+        </p>
+        <AnnualBudgetSummary />
+      </div>
 
       <div>
         <h2 className="text-primary-content text-lg">ファイル一覧</h2>

--- a/src/pages/RootPage/RootPage.tsx
+++ b/src/pages/RootPage/RootPage.tsx
@@ -10,6 +10,7 @@ import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { MonthlyTotalChart } from "./components/MonthlyTotalChart";
+import { AnnualBudgetSummary } from "./components/AnnualBudgetSummary";
 import { formatYen } from "../../utils/formatYen";
 
 export function RootPage() {
@@ -107,10 +108,20 @@ export function RootPage() {
       </div>
 
       {files && files.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <h2 className="text-primary-content text-lg">月別推移</h2>
-          <MonthlyTotalChart files={files} />
-        </div>
+        <>
+          <div className="flex flex-col gap-2">
+            <h2 className="text-primary-content text-lg">月別推移</h2>
+            <MonthlyTotalChart files={files} />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <h2 className="text-primary-content text-lg">年間予算</h2>
+            <p className="text-info text-sm">
+              年予算は設定ページから各カテゴリに設定できます。未設定のカテゴリは過去データの月平均×12を暫定値として表示します。
+            </p>
+            <AnnualBudgetSummary />
+          </div>
+        </>
       )}
 
       <div>

--- a/src/pages/RootPage/components/AnnualBudgetSummary.tsx
+++ b/src/pages/RootPage/components/AnnualBudgetSummary.tsx
@@ -1,0 +1,59 @@
+import clsx from "clsx";
+import { useAnnualBudgetSummary } from "../../../data";
+import { formatYen } from "../../../utils/formatYen";
+
+export function AnnualBudgetSummary() {
+  const result = useAnnualBudgetSummary();
+
+  if (result.status === "loading") {
+    return (
+      <div className="flex justify-center py-4">
+        <span className="loading loading-spinner loading-md" />
+      </div>
+    );
+  }
+
+  if (result.items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="table">
+        <thead>
+          <tr>
+            <th>カテゴリ</th>
+            <th>年予算</th>
+            <th>今年の支出</th>
+            <th>残り</th>
+          </tr>
+        </thead>
+        <tbody>
+          {result.items.map((item) => (
+            <tr key={item.categoryId}>
+              <td className="font-medium">{item.categoryName}</td>
+              <td>
+                <span>{formatYen(item.annualBudget)}</span>
+                {item.isFallback && (
+                  <span className="badge badge-ghost badge-sm ml-2">暫定</span>
+                )}
+              </td>
+              <td>{formatYen(item.currentYearTotal)}</td>
+              <td>
+                <span
+                  className={clsx(
+                    "font-medium",
+                    item.remaining >= 0 ? "text-success" : "text-error",
+                  )}
+                >
+                  {item.remaining >= 0 ? "" : "−"}
+                  {formatYen(Math.abs(item.remaining))}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/SettingsPage/components/CategoryItem.tsx
+++ b/src/pages/SettingsPage/components/CategoryItem.tsx
@@ -21,6 +21,9 @@ export function CategoryItem({ category }: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(category.name);
+  const [editAnnualBudget, setEditAnnualBudget] = useState(
+    category.annualBudget !== undefined ? String(category.annualBudget) : "",
+  );
   const rulesResult = useCategoryRules({ categoryId: category.id });
 
   const { attributes, listeners, setNodeRef, transform, transition } =
@@ -34,10 +37,23 @@ export function CategoryItem({ category }: Props) {
   const handleUpdate = async () => {
     if (!editName.trim()) return;
 
+    const parsedBudget = editAnnualBudget.trim()
+      ? Number(editAnnualBudget.trim())
+      : undefined;
+
+    if (
+      parsedBudget !== undefined &&
+      (isNaN(parsedBudget) || parsedBudget < 0)
+    ) {
+      alert("年予算には0以上の整数を入力してください。");
+      return;
+    }
+
     try {
       await updateCategory({
         id: category.id,
         name: editName.trim(),
+        annualBudget: parsedBudget,
       });
       setIsEditing(false);
     } catch {
@@ -90,42 +106,78 @@ export function CategoryItem({ category }: Props) {
         </button>
 
         {isEditing ? (
-          <div className="flex flex-1 items-center gap-2">
-            <input
-              type="text"
-              className="input input-bordered input-sm flex-1"
-              value={editName}
-              onChange={(e) => setEditName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") void handleUpdate();
-                if (e.key === "Escape") {
+          <div className="flex flex-1 flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                className="input input-bordered input-sm flex-1"
+                value={editName}
+                placeholder="カテゴリ名"
+                onChange={(e) => setEditName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setIsEditing(false);
+                    setEditName(category.name);
+                    setEditAnnualBudget(
+                      category.annualBudget !== undefined
+                        ? String(category.annualBudget)
+                        : "",
+                    );
+                  }
+                }}
+                autoFocus
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="text-base-content/70 text-sm whitespace-nowrap">
+                年予算
+              </label>
+              <input
+                type="number"
+                className="input input-bordered input-sm w-40"
+                value={editAnnualBudget}
+                placeholder="未設定"
+                min={0}
+                onChange={(e) => setEditAnnualBudget(e.target.value)}
+              />
+              <span className="text-base-content/70 text-sm">円</span>
+              <span className="text-base-content/50 text-xs">
+                （空欄で未設定）
+              </span>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="btn btn-primary btn-sm"
+                onClick={() => void handleUpdate()}
+              >
+                保存
+              </button>
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => {
                   setIsEditing(false);
                   setEditName(category.name);
-                }
-              }}
-              autoFocus
-            />
-            <button
-              type="button"
-              className="btn btn-primary btn-sm"
-              onClick={() => void handleUpdate()}
-            >
-              保存
-            </button>
-            <button
-              type="button"
-              className="btn btn-ghost btn-sm"
-              onClick={() => {
-                setIsEditing(false);
-                setEditName(category.name);
-              }}
-            >
-              キャンセル
-            </button>
+                  setEditAnnualBudget(
+                    category.annualBudget !== undefined
+                      ? String(category.annualBudget)
+                      : "",
+                  );
+                }}
+              >
+                キャンセル
+              </button>
+            </div>
           </div>
         ) : (
           <>
             <span className="flex-1 font-medium">{category.name}</span>
+            {category.annualBudget !== undefined && (
+              <span className="text-base-content/60 text-sm">
+                年予算 {category.annualBudget.toLocaleString()}円
+              </span>
+            )}
             <span className="text-base-content/60 text-sm">
               {rulesResult.status === "completed"
                 ? `${rulesResult.rules.length} ルール`

--- a/src/pages/SettingsPage/components/CategoryItem.tsx
+++ b/src/pages/SettingsPage/components/CategoryItem.tsx
@@ -43,7 +43,9 @@ export function CategoryItem({ category }: Props) {
 
     if (
       parsedBudget !== undefined &&
-      (isNaN(parsedBudget) || parsedBudget < 0)
+      (!Number.isFinite(parsedBudget) ||
+        !Number.isInteger(parsedBudget) ||
+        parsedBudget < 0)
     ) {
       alert("年予算には0以上の整数を入力してください。");
       return;
@@ -106,7 +108,24 @@ export function CategoryItem({ category }: Props) {
         </button>
 
         {isEditing ? (
-          <div className="flex flex-1 flex-col gap-2">
+          <form
+            className="flex flex-1 flex-col gap-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleUpdate();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                setIsEditing(false);
+                setEditName(category.name);
+                setEditAnnualBudget(
+                  category.annualBudget !== undefined
+                    ? String(category.annualBudget)
+                    : "",
+                );
+              }
+            }}
+          >
             <div className="flex items-center gap-2">
               <input
                 type="text"
@@ -114,17 +133,6 @@ export function CategoryItem({ category }: Props) {
                 value={editName}
                 placeholder="カテゴリ名"
                 onChange={(e) => setEditName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Escape") {
-                    setIsEditing(false);
-                    setEditName(category.name);
-                    setEditAnnualBudget(
-                      category.annualBudget !== undefined
-                        ? String(category.annualBudget)
-                        : "",
-                    );
-                  }
-                }}
                 autoFocus
               />
             </div>
@@ -138,6 +146,7 @@ export function CategoryItem({ category }: Props) {
                 value={editAnnualBudget}
                 placeholder="未設定"
                 min={0}
+                step={1}
                 onChange={(e) => setEditAnnualBudget(e.target.value)}
               />
               <span className="text-base-content/70 text-sm">円</span>
@@ -146,11 +155,7 @@ export function CategoryItem({ category }: Props) {
               </span>
             </div>
             <div className="flex gap-2">
-              <button
-                type="button"
-                className="btn btn-primary btn-sm"
-                onClick={() => void handleUpdate()}
-              >
+              <button type="submit" className="btn btn-primary btn-sm">
                 保存
               </button>
               <button
@@ -169,7 +174,7 @@ export function CategoryItem({ category }: Props) {
                 キャンセル
               </button>
             </div>
-          </div>
+          </form>
         ) : (
           <>
             <span className="flex-1 font-medium">{category.name}</span>


### PR DESCRIPTION
close #125

## 概要

カテゴリに「年予算」を設定し、今年の累計支出との比較・残り使える額をホーム画面で表示する機能を追加。

## 変更内容

### データ層

- `Category` 型に `annualBudget?: number` フィールドを追加（Dexie スキーマは索引変更なしのため version bump 不要）
- `updateCategory` を `put` 方式に変更し、年予算の設定・削除両方に対応

### 設定画面（`/settings`）

- カテゴリ編集 UI に年予算入力欄（数値、空欄で未設定）を追加
- バリデーション: `Number.isFinite` + `Number.isInteger` + `>= 0` による厳格チェック
- `<form>` 要素でラップし Enter 保存（既存操作性）を維持、Escape でキャンセル

### ホーム画面（`/`）

- `useAnnualBudgetSummary` フック: 全ファイルから今年の支出をカテゴリ別に集計
  - 年予算設定済み: 設定値をそのまま使用
  - 年予算未設定: 過去の月平均 × 12 を暫定値として表示（`暫定` バッジ付き）
- `AnnualBudgetSummary` コンポーネントをホーム画面に追加（ファイル登録有無に関わらず表示）
- 表示項目: カテゴリ名 / 年予算（設定値 or 暫定）/ 今年の支出 / 残り（超過時は赤色）

## ローカル検証手順

```bash
npm run dev
```

1. `/settings` でカテゴリに年予算を設定 → 保存後一覧に金額が表示されること
2. ホーム画面で「年間予算」セクションに集計が表示されること
3. 年予算未設定カテゴリには「暫定」バッジが付くこと
4. 今年の支出が予算超過のカテゴリで残り額が赤色表示されること
5. 年予算フィールドに小数・負数を入力するとバリデーションエラーになること

## 影響パッケージパス

- `src/data/db.ts`
- `src/data/categories/updateCategory.ts`
- `src/data/payments/useAnnualBudgetSummary.ts`（新規）
- `src/pages/SettingsPage/components/CategoryItem.tsx`
- `src/pages/RootPage/components/AnnualBudgetSummary.tsx`（新規）
- `src/pages/RootPage/RootPage.tsx`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)