### PR TITLE
chore: actions/checkout を v4 から v6 に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: "22"


### PR DESCRIPTION
## 変更内容

`actions/checkout` を最新バージョンに更新した。

- `actions/checkout@v4` → `actions/checkout@v6`（最新: v6.0.2）