### PR TITLE
feat: カテゴリに固有色を割り当てる

### DIFF
--- a/src/data/categories/addCategory.test.ts
+++ b/src/data/categories/addCategory.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
   });
 });
 
-test("正常系: カテゴリが存在しない場合、order=0で追加される", async () => {
+test("正常系: カテゴリが存在しない場合、order=0でデフォルト色付きで追加される", async () => {
   vi.mocked(db.categories.orderBy).mockReturnValue({
     last: vi.fn().mockResolvedValue(undefined),
   } as never);
@@ -32,10 +32,11 @@ test("正常系: カテゴリが存在しない場合、order=0で追加され�
     id: "test-uuid-1234",
     name: "食費",
     order: 0,
+    color: "#8B5CF6",
   });
 });
 
-test("正常系: 既存カテゴリがある場合、order=maxOrder+1で追加される", async () => {
+test("正常系: 既存カテゴリがある場合、order=maxOrder+1でデフォルト色付きで追加される", async () => {
   vi.mocked(db.categories.orderBy).mockReturnValue({
     last: vi.fn().mockResolvedValue({ id: "existing", name: "既存", order: 5 }),
   } as never);
@@ -48,6 +49,24 @@ test("正常系: 既存カテゴリがある場合、order=maxOrder+1で追加�
     id: "test-uuid-1234",
     name: "交通費",
     order: 6,
+    color: "#EC4899",
+  });
+});
+
+test("正常系: 色を明示指定した場合、指定色で追加される", async () => {
+  vi.mocked(db.categories.orderBy).mockReturnValue({
+    last: vi.fn().mockResolvedValue(undefined),
+  } as never);
+  vi.mocked(db.categories.add).mockResolvedValue("test-uuid-1234" as never);
+
+  const result = await addCategory({ name: "食費", color: "#FF0000" });
+
+  expect(result).toBe("test-uuid-1234");
+  expect(db.categories.add).toHaveBeenCalledWith({
+    id: "test-uuid-1234",
+    name: "食費",
+    order: 0,
+    color: "#FF0000",
   });
 });
 

--- a/src/data/categories/addCategory.ts
+++ b/src/data/categories/addCategory.ts
@@ -1,16 +1,19 @@
 import { db } from "../db";
 import { getNextOrder } from "../utils/getNextOrder";
+import { getDefaultColor } from "./categoryColors";
 
-type Input = { name: string };
+type Input = { name: string; color?: string };
 
 export async function addCategory(input: Input): Promise<string> {
   const id = crypto.randomUUID();
   const order = await getNextOrder("categories");
+  const color = input.color ?? getDefaultColor(order);
 
   await db.categories.add({
     id,
     name: input.name,
     order,
+    color,
   });
 
   return id;

--- a/src/data/categories/categoryColors.ts
+++ b/src/data/categories/categoryColors.ts
@@ -1,0 +1,16 @@
+export const DEFAULT_CATEGORY_COLORS = [
+  "#8B5CF6",
+  "#06B6D4",
+  "#10B981",
+  "#F59E0B",
+  "#EF4444",
+  "#3B82F6",
+  "#EC4899",
+  "#84CC16",
+  "#F97316",
+  "#6366F1",
+];
+
+export function getDefaultColor(index: number): string {
+  return DEFAULT_CATEGORY_COLORS[index % DEFAULT_CATEGORY_COLORS.length];
+}

--- a/src/data/categories/updateCategory.test.ts
+++ b/src/data/categories/updateCategory.test.ts
@@ -96,6 +96,48 @@ test("正常系: 既存の月予算が別の値に更新される", async () => 
   });
 });
 
+test("正常系: 色が更新される", async () => {
+  vi.mocked(db.categories.get).mockResolvedValue({
+    id: "category-1",
+    name: "食費",
+    order: 0,
+    color: "#8B5CF6",
+  } as never);
+  vi.mocked(db.categories.put).mockResolvedValue("category-1" as never);
+
+  await updateCategory({
+    id: "category-1",
+    name: "食費",
+    color: "#EF4444",
+  });
+
+  expect(db.categories.put).toHaveBeenCalledWith({
+    id: "category-1",
+    name: "食費",
+    order: 0,
+    color: "#EF4444",
+  });
+});
+
+test("正常系: 色が未指定の場合は既存の色を保持する", async () => {
+  vi.mocked(db.categories.get).mockResolvedValue({
+    id: "category-1",
+    name: "食費",
+    order: 0,
+    color: "#8B5CF6",
+  } as never);
+  vi.mocked(db.categories.put).mockResolvedValue("category-1" as never);
+
+  await updateCategory({ id: "category-1", name: "食費" });
+
+  expect(db.categories.put).toHaveBeenCalledWith({
+    id: "category-1",
+    name: "食費",
+    order: 0,
+    color: "#8B5CF6",
+  });
+});
+
 test("正常系: カテゴリが存在しない場合は何もしない", async () => {
   vi.mocked(db.categories.get).mockResolvedValue(undefined as never);
 

--- a/src/data/categories/updateCategory.ts
+++ b/src/data/categories/updateCategory.ts
@@ -1,9 +1,14 @@
 import { db, type Category } from "../db";
 
-type Input = { id: string; name: string; monthlyBudget?: number };
+type Input = {
+  id: string;
+  name: string;
+  monthlyBudget?: number;
+  color?: string;
+};
 
 export async function updateCategory(input: Input): Promise<void> {
-  const { id, name, monthlyBudget } = input;
+  const { id, name, monthlyBudget, color } = input;
 
   const existing = await db.categories.get(id);
   if (!existing) return;
@@ -13,6 +18,11 @@ export async function updateCategory(input: Input): Promise<void> {
     name,
     order: existing.order,
     ...(monthlyBudget !== undefined ? { monthlyBudget } : {}),
+    ...(color !== undefined
+      ? { color }
+      : existing.color !== undefined
+        ? { color: existing.color }
+        : {}),
   };
 
   await db.categories.put(updated);

--- a/src/data/db.migration.test.ts
+++ b/src/data/db.migration.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, expect, test } from "vitest";
+import Dexie, { type EntityTable } from "dexie";
+
+type CategoryV4 = {
+  id: string;
+  name: string;
+  order: number;
+  color?: string;
+};
+
+type TestDB = Dexie & {
+  categories: EntityTable<CategoryV4, "id">;
+  categoryRules: EntityTable<{ id: string }, "id">;
+  paymentFiles: EntityTable<{ fileName: string }, "fileName">;
+};
+
+const V5_MIGRATION_COLORS = [
+  "#8B5CF6",
+  "#06B6D4",
+  "#10B981",
+  "#F59E0B",
+  "#EF4444",
+  "#3B82F6",
+  "#EC4899",
+  "#84CC16",
+  "#F97316",
+  "#6366F1",
+];
+
+let dbName: string;
+
+beforeEach(() => {
+  dbName = `test-migration-${Date.now()}-${Math.random()}`;
+});
+
+async function createV4Database(name: string) {
+  const db = new Dexie(name);
+  db.version(1).stores({ paymentFiles: "fileName" });
+  db.version(2).stores({
+    paymentFiles: "fileName",
+    tags: "id, order",
+    tagRules: "id, tagId, order",
+  });
+  db.version(3).stores({
+    paymentFiles: "fileName",
+    categories: "id, order",
+    categoryRules: "id, categoryId, order",
+    tags: null,
+    tagRules: null,
+  });
+  db.version(4).stores({
+    paymentFiles: "fileName",
+    categories: "id, order",
+    categoryRules: "id, categoryId, order",
+  });
+  await db.open();
+  return db;
+}
+
+async function openV5Database(name: string) {
+  const db = new Dexie(name);
+  db.version(1).stores({ paymentFiles: "fileName" });
+  db.version(2).stores({
+    paymentFiles: "fileName",
+    tags: "id, order",
+    tagRules: "id, tagId, order",
+  });
+  db.version(3).stores({
+    paymentFiles: "fileName",
+    categories: "id, order",
+    categoryRules: "id, categoryId, order",
+    tags: null,
+    tagRules: null,
+  });
+  db.version(4).stores({
+    paymentFiles: "fileName",
+    categories: "id, order",
+    categoryRules: "id, categoryId, order",
+  });
+  db.version(5)
+    .stores({
+      paymentFiles: "fileName",
+      categories: "id, order",
+      categoryRules: "id, categoryId, order",
+    })
+    .upgrade(async (tx) => {
+      const categories = await tx
+        .table("categories")
+        .orderBy("order")
+        .toArray();
+      await tx.table("categories").bulkPut(
+        categories.map(
+          (cat: { color?: string; [key: string]: unknown }, index: number) =>
+            cat.color === undefined
+              ? {
+                  ...cat,
+                  color:
+                    V5_MIGRATION_COLORS[index % V5_MIGRATION_COLORS.length],
+                }
+              : cat,
+        ),
+      );
+    });
+  await db.open();
+  return db;
+}
+
+test("v5マイグレーション: colorのないカテゴリに順序ベースで色が割り当てられる", async () => {
+  const dbV4 = await createV4Database(dbName);
+  await (dbV4 as unknown as TestDB).categories.bulkAdd([
+    { id: "cat-1", name: "食費", order: 0 },
+    { id: "cat-2", name: "交通費", order: 1 },
+    { id: "cat-3", name: "趣味", order: 2 },
+  ]);
+  dbV4.close();
+
+  const dbV5 = await openV5Database(dbName);
+  const categories = await (dbV5 as unknown as TestDB).categories
+    .orderBy("order")
+    .toArray();
+
+  expect(categories[0].color).toBe(V5_MIGRATION_COLORS[0]);
+  expect(categories[1].color).toBe(V5_MIGRATION_COLORS[1]);
+  expect(categories[2].color).toBe(V5_MIGRATION_COLORS[2]);
+
+  dbV5.close();
+});
+
+test("v5マイグレーション: 既にcolorを持つカテゴリは上書きされない", async () => {
+  const dbV4 = await createV4Database(dbName);
+  await (dbV4 as unknown as TestDB).categories.bulkAdd([
+    { id: "cat-1", name: "食費", order: 0, color: "#FF0000" },
+    { id: "cat-2", name: "交通費", order: 1 },
+  ]);
+  dbV4.close();
+
+  const dbV5 = await openV5Database(dbName);
+  const categories = await (dbV5 as unknown as TestDB).categories
+    .orderBy("order")
+    .toArray();
+
+  expect(categories[0].color).toBe("#FF0000");
+  expect(categories[1].color).toBe(V5_MIGRATION_COLORS[1]);
+
+  dbV5.close();
+});
+
+test("v5マイグレーション: カテゴリが10件を超えるとカラーパレットがサイクルする", async () => {
+  const dbV4 = await createV4Database(dbName);
+  const items = Array.from({ length: 12 }, (_, i) => ({
+    id: `cat-${i}`,
+    name: `カテゴリ${i}`,
+    order: i,
+  }));
+  await (dbV4 as unknown as TestDB).categories.bulkAdd(items);
+  dbV4.close();
+
+  const dbV5 = await openV5Database(dbName);
+  const categories = await (dbV5 as unknown as TestDB).categories
+    .orderBy("order")
+    .toArray();
+
+  expect(categories[10].color).toBe(V5_MIGRATION_COLORS[0]);
+  expect(categories[11].color).toBe(V5_MIGRATION_COLORS[1]);
+
+  dbV5.close();
+});

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -1,5 +1,4 @@
 import Dexie, { type EntityTable } from "dexie";
-import { DEFAULT_CATEGORY_COLORS } from "./categories/categoryColors";
 
 type Payment = {
   name: string;
@@ -85,6 +84,20 @@ db.version(4)
     );
   });
 
+// このスナップショットは v4→v5 マイグレーション専用。後から変更しないこと。
+const V5_MIGRATION_COLORS = [
+  "#8B5CF6",
+  "#06B6D4",
+  "#10B981",
+  "#F59E0B",
+  "#EF4444",
+  "#3B82F6",
+  "#EC4899",
+  "#84CC16",
+  "#F97316",
+  "#6366F1",
+];
+
 db.version(5)
   .stores({
     paymentFiles: "fileName",
@@ -99,10 +112,7 @@ db.version(5)
           cat.color === undefined
             ? {
                 ...cat,
-                color:
-                  DEFAULT_CATEGORY_COLORS[
-                    index % DEFAULT_CATEGORY_COLORS.length
-                  ],
+                color: V5_MIGRATION_COLORS[index % V5_MIGRATION_COLORS.length],
               }
             : cat,
       ),

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -1,4 +1,5 @@
 import Dexie, { type EntityTable } from "dexie";
+import { DEFAULT_CATEGORY_COLORS } from "./categories/categoryColors";
 
 type Payment = {
   name: string;
@@ -17,6 +18,7 @@ interface Category {
   name: string;
   order: number;
   monthlyBudget?: number;
+  color?: string;
 }
 
 interface CategoryRule {
@@ -79,6 +81,30 @@ db.version(4)
             ? { ...rest, monthlyBudget: annualBudget }
             : rest;
         },
+      ),
+    );
+  });
+
+db.version(5)
+  .stores({
+    paymentFiles: "fileName",
+    categories: "id, order",
+    categoryRules: "id, categoryId, order",
+  })
+  .upgrade(async (tx) => {
+    const categories = await tx.table("categories").orderBy("order").toArray();
+    await tx.table("categories").bulkPut(
+      categories.map(
+        (cat: { color?: string; [key: string]: unknown }, index: number) =>
+          cat.color === undefined
+            ? {
+                ...cat,
+                color:
+                  DEFAULT_CATEGORY_COLORS[
+                    index % DEFAULT_CATEGORY_COLORS.length
+                  ],
+              }
+            : cat,
       ),
     );
   });

--- a/src/data/payments/usePaymentsByCategory.ts
+++ b/src/data/payments/usePaymentsByCategory.ts
@@ -9,6 +9,7 @@ type Props = {
 type CategoryInfo = {
   id: string;
   name: string;
+  color?: string;
 } | null;
 
 type PaymentDetail = {
@@ -65,7 +66,11 @@ export function usePaymentsByCategory({
           if (
             normalizeSpaces(paymentName).includes(normalizeSpaces(rule.pattern))
           ) {
-            return { id: category.id, name: category.name };
+            return {
+              id: category.id,
+              name: category.name,
+              color: category.color,
+            };
           }
         }
       }

--- a/src/pages/DetailPage/components/PaymentCategoryView/CategoryBreakdownRow.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/CategoryBreakdownRow.tsx
@@ -13,6 +13,7 @@ type PaymentDetail = {
 type CategoryInfo = {
   id: string;
   name: string;
+  color?: string;
 } | null;
 
 type SubBreakdownItem = {
@@ -93,7 +94,13 @@ export function CategoryBreakdownRow({ item, index }: Props) {
             )}
           </span>
           {item.category ? (
-            <span className="badge badge-primary">{item.category.name}</span>
+            <span className="inline-flex items-center gap-1.5">
+              <span
+                className="inline-block h-3 w-3 flex-shrink-0 rounded-full"
+                style={{ backgroundColor: item.category.color ?? "#8B5CF6" }}
+              />
+              <span>{item.category.name}</span>
+            </span>
           ) : (
             <span className="text-base-content/60">未分類</span>
           )}

--- a/src/pages/DetailPage/components/PaymentCategoryView/CategoryBreakdownRow.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/CategoryBreakdownRow.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import { ChevronRightIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
 import { PaymentDetailTable } from "./PaymentDetailTable";
 import { formatYen } from "../../../../utils/formatYen";
+import { DEFAULT_CATEGORY_COLORS } from "../../../../data/categories/categoryColors";
 
 type PaymentDetail = {
   name: string;
@@ -97,7 +98,10 @@ export function CategoryBreakdownRow({ item, index }: Props) {
             <span className="inline-flex items-center gap-1.5">
               <span
                 className="inline-block h-3 w-3 flex-shrink-0 rounded-full"
-                style={{ backgroundColor: item.category.color ?? "#8B5CF6" }}
+                style={{
+                  backgroundColor:
+                    item.category.color ?? DEFAULT_CATEGORY_COLORS[0],
+                }}
               />
               <span>{item.category.name}</span>
             </span>

--- a/src/pages/DetailPage/components/PaymentCategoryView/PaymentCategoryView.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PaymentCategoryView.tsx
@@ -29,6 +29,7 @@ export function PaymentCategoryView({ fileName }: Props) {
   const chartData = breakdown.slice(0, 20).map((item) => ({
     name: item.category?.name || "未分類",
     value: item.total,
+    color: item.category?.color,
   }));
 
   const hasNoData = breakdown.length === 0;

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
@@ -9,11 +9,11 @@ import {
 } from "recharts";
 import { formatYen } from "../../../../utils/formatYen";
 
-type Props = {
-  data: { name: string; value: number }[];
-};
+import { DEFAULT_CATEGORY_COLORS } from "../../../../data/categories/categoryColors";
 
-const COLORS = ["#8B5CF6", "#06B6D4", "#10B981", "#F59E0B", "#EF4444"];
+type Props = {
+  data: { name: string; value: number; color?: string }[];
+};
 
 export function PayviewCategoryBarChart({ data }: Props) {
   return (
@@ -25,7 +25,15 @@ export function PayviewCategoryBarChart({ data }: Props) {
           <Tooltip formatter={(value: number) => [formatYen(value), "金額"]} />
           <Bar dataKey="value">
             {data.map((item, index) => (
-              <Cell key={item.name} fill={COLORS[index % COLORS.length]} />
+              <Cell
+                key={item.name}
+                fill={
+                  item.color ??
+                  DEFAULT_CATEGORY_COLORS[
+                    index % DEFAULT_CATEGORY_COLORS.length
+                  ]
+                }
+              />
             ))}
           </Bar>
         </BarChart>

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryPieChart.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryPieChart.tsx
@@ -1,11 +1,10 @@
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
 import { formatYen } from "../../../../utils/formatYen";
+import { DEFAULT_CATEGORY_COLORS } from "../../../../data/categories/categoryColors";
 
 type Props = {
-  data: { name: string; value: number }[];
+  data: { name: string; value: number; color?: string }[];
 };
-
-const COLORS = ["#8B5CF6", "#06B6D4", "#10B981", "#F59E0B", "#EF4444"];
 
 export function PayviewCategoryPieChart({ data }: Props) {
   return (
@@ -23,7 +22,15 @@ export function PayviewCategoryPieChart({ data }: Props) {
             endAngle={-270}
           >
             {data.map((item, index) => (
-              <Cell key={item.name} fill={COLORS[index % COLORS.length]} />
+              <Cell
+                key={item.name}
+                fill={
+                  item.color ??
+                  DEFAULT_CATEGORY_COLORS[
+                    index % DEFAULT_CATEGORY_COLORS.length
+                  ]
+                }
+              />
             ))}
           </Pie>
           <Tooltip

--- a/src/pages/SettingsPage/components/CategoryItem.tsx
+++ b/src/pages/SettingsPage/components/CategoryItem.tsx
@@ -24,6 +24,7 @@ export function CategoryItem({ category }: Props) {
   const [editMonthlyBudget, setEditMonthlyBudget] = useState(
     category.monthlyBudget !== undefined ? String(category.monthlyBudget) : "",
   );
+  const [editColor, setEditColor] = useState(category.color ?? "#8B5CF6");
   const rulesResult = useCategoryRules({ categoryId: category.id });
 
   const { attributes, listeners, setNodeRef, transform, transition } =
@@ -56,6 +57,7 @@ export function CategoryItem({ category }: Props) {
         id: category.id,
         name: editName.trim(),
         monthlyBudget: parsedBudget,
+        color: editColor,
       });
       setIsEditing(false);
     } catch {
@@ -123,6 +125,7 @@ export function CategoryItem({ category }: Props) {
                     ? String(category.monthlyBudget)
                     : "",
                 );
+                setEditColor(category.color ?? "#8B5CF6");
               }
             }}
           >
@@ -134,6 +137,17 @@ export function CategoryItem({ category }: Props) {
                 placeholder="カテゴリ名"
                 onChange={(e) => setEditName(e.target.value)}
                 autoFocus
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="text-base-content/70 text-sm whitespace-nowrap">
+                カラー
+              </label>
+              <input
+                type="color"
+                className="h-8 w-14 cursor-pointer rounded border"
+                value={editColor}
+                onChange={(e) => setEditColor(e.target.value)}
               />
             </div>
             <div className="flex items-center gap-2">
@@ -169,6 +183,7 @@ export function CategoryItem({ category }: Props) {
                       ? String(category.monthlyBudget)
                       : "",
                   );
+                  setEditColor(category.color ?? "#8B5CF6");
                 }}
               >
                 キャンセル
@@ -177,7 +192,13 @@ export function CategoryItem({ category }: Props) {
           </form>
         ) : (
           <>
-            <span className="flex-1 font-medium">{category.name}</span>
+            <span className="flex flex-1 items-center gap-2 font-medium">
+              <span
+                className="inline-block h-3 w-3 flex-shrink-0 rounded-full"
+                style={{ backgroundColor: category.color ?? "#8B5CF6" }}
+              />
+              {category.name}
+            </span>
             {category.monthlyBudget !== undefined && (
               <span className="text-base-content/60 text-sm">
                 月予算 {category.monthlyBudget.toLocaleString()}円

--- a/src/pages/SettingsPage/components/CategoryItem.tsx
+++ b/src/pages/SettingsPage/components/CategoryItem.tsx
@@ -9,6 +9,7 @@ import {
 import { type Category } from "../../../data/db";
 import { updateCategory } from "../../../data/categories/updateCategory";
 import { deleteCategory } from "../../../data/categories/deleteCategory";
+import { DEFAULT_CATEGORY_COLORS } from "../../../data/categories/categoryColors";
 import { useCategoryRules } from "../../../data/categories/useCategoryRules";
 import { CategoryRuleList } from "./CategoryRuleList";
 import { AddCategoryRuleForm } from "./AddCategoryRuleForm";
@@ -24,7 +25,9 @@ export function CategoryItem({ category }: Props) {
   const [editMonthlyBudget, setEditMonthlyBudget] = useState(
     category.monthlyBudget !== undefined ? String(category.monthlyBudget) : "",
   );
-  const [editColor, setEditColor] = useState(category.color ?? "#8B5CF6");
+  const [editColor, setEditColor] = useState(
+    category.color ?? DEFAULT_CATEGORY_COLORS[0],
+  );
   const rulesResult = useCategoryRules({ categoryId: category.id });
 
   const { attributes, listeners, setNodeRef, transform, transition } =
@@ -125,7 +128,7 @@ export function CategoryItem({ category }: Props) {
                     ? String(category.monthlyBudget)
                     : "",
                 );
-                setEditColor(category.color ?? "#8B5CF6");
+                setEditColor(category.color ?? DEFAULT_CATEGORY_COLORS[0]);
               }
             }}
           >
@@ -183,7 +186,7 @@ export function CategoryItem({ category }: Props) {
                       ? String(category.monthlyBudget)
                       : "",
                   );
-                  setEditColor(category.color ?? "#8B5CF6");
+                  setEditColor(category.color ?? DEFAULT_CATEGORY_COLORS[0]);
                 }}
               >
                 キャンセル
@@ -195,7 +198,9 @@ export function CategoryItem({ category }: Props) {
             <span className="flex flex-1 items-center gap-2 font-medium">
               <span
                 className="inline-block h-3 w-3 flex-shrink-0 rounded-full"
-                style={{ backgroundColor: category.color ?? "#8B5CF6" }}
+                style={{
+                  backgroundColor: category.color ?? DEFAULT_CATEGORY_COLORS[0],
+                }}
               />
               {category.name}
             </span>


### PR DESCRIPTION
close #129

## 概要

- `Category` 型に `color` フィールド（任意）を追加
- DBマイグレーション (v5) で既存カテゴリに順序ベースのデフォルト色を付与
- `addCategory` でカテゴリ作成時にデフォルト色を自動割り当て
- カテゴリ別内訳テーブルの各行に色チップ（●）を表示
- バーチャート・円グラフをカテゴリ固有色で描画
- 設定画面のカテゴリ編集フォームにカラーピッカーを追加

## 影響パッケージパス

- `src/data/db.ts` — `Category` 型拡張、DBマイグレーション v5 追加
- `src/data/categories/categoryColors.ts` — デフォルトカラーパレット定義（新規）
- `src/data/categories/addCategory.ts` / `updateCategory.ts` — color フィールド対応
- `src/data/payments/usePaymentsByCategory.ts` — `CategoryInfo` 型に color 追加
- `src/pages/DetailPage/components/PaymentCategoryView/` — テーブル・バーチャート・円グラフの色対応
- `src/pages/SettingsPage/components/CategoryItem.tsx` — カラーピッカー追加

## ローカル検証手順

1. `npm run dev` でアプリを起動
2. 設定画面でカテゴリを確認 → 各カテゴリ名の左に色チップが表示される
3. 「編集」ボタンを押すとカラーピッカーが表示され、色を変更できる
4. 支払い詳細画面のカテゴリ別内訳テーブルで各行に色チップが表示される
5. バーチャート・円グラフの各要素がカテゴリの固有色で描画される