### PR TITLE
feat: PRプレビュー環境の初回アクセス時にダミーデータを自動投入する

### DIFF
--- a/src/dev/seed.test.ts
+++ b/src/dev/seed.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { seedIfNeeded } from "./seed";
+
+vi.mock("../data", () => ({
+  db: {
+    paymentFiles: {
+      count: vi.fn(),
+      bulkPut: vi.fn(),
+    },
+    categories: {
+      bulkPut: vi.fn(),
+    },
+    categoryRules: {
+      bulkPut: vi.fn(),
+    },
+    transaction: vi.fn(
+      (_mode: unknown, _tables: unknown, callback: () => Promise<void>) =>
+        callback(),
+    ),
+  },
+}));
+
+import { db } from "../data";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+test("VITE_ENABLE_SEED が未設定のとき、何も実行されない", async () => {
+  await seedIfNeeded();
+
+  expect(db.paymentFiles.count).not.toHaveBeenCalled();
+  expect(db.transaction).not.toHaveBeenCalled();
+});
+
+test("VITE_ENABLE_SEED=true かつ paymentFiles が空でないとき、スキップする", async () => {
+  vi.stubEnv("VITE_ENABLE_SEED", "true");
+  vi.mocked(db.paymentFiles.count).mockResolvedValue(3);
+
+  await seedIfNeeded();
+
+  expect(db.transaction).not.toHaveBeenCalled();
+});
+
+test("VITE_ENABLE_SEED=true かつ paymentFiles が空のとき、3テーブルに bulkPut する", async () => {
+  vi.stubEnv("VITE_ENABLE_SEED", "true");
+  vi.mocked(db.paymentFiles.count).mockResolvedValue(0);
+
+  await seedIfNeeded();
+
+  expect(db.transaction).toHaveBeenCalledOnce();
+  expect(db.paymentFiles.bulkPut).toHaveBeenCalledOnce();
+  expect(db.categories.bulkPut).toHaveBeenCalledOnce();
+  expect(db.categoryRules.bulkPut).toHaveBeenCalledOnce();
+});

--- a/src/dev/seed.ts
+++ b/src/dev/seed.ts
@@ -1,0 +1,23 @@
+import { db } from "../data";
+import {
+  SEED_CATEGORIES,
+  SEED_CATEGORY_RULES,
+  SEED_PAYMENT_FILES,
+} from "./seedData";
+
+export async function seedIfNeeded(): Promise<void> {
+  if (import.meta.env.VITE_ENABLE_SEED !== "true") return;
+
+  const count = await db.paymentFiles.count();
+  if (count > 0) return;
+
+  await db.transaction(
+    "rw",
+    [db.paymentFiles, db.categories, db.categoryRules],
+    async () => {
+      await db.paymentFiles.bulkAdd(SEED_PAYMENT_FILES);
+      await db.categories.bulkAdd(SEED_CATEGORIES);
+      await db.categoryRules.bulkAdd(SEED_CATEGORY_RULES);
+    },
+  );
+}

--- a/src/dev/seed.ts
+++ b/src/dev/seed.ts
@@ -15,9 +15,9 @@ export async function seedIfNeeded(): Promise<void> {
     "rw",
     [db.paymentFiles, db.categories, db.categoryRules],
     async () => {
-      await db.paymentFiles.bulkAdd(SEED_PAYMENT_FILES);
-      await db.categories.bulkAdd(SEED_CATEGORIES);
-      await db.categoryRules.bulkAdd(SEED_CATEGORY_RULES);
+      await db.paymentFiles.bulkPut(SEED_PAYMENT_FILES);
+      await db.categories.bulkPut(SEED_CATEGORIES);
+      await db.categoryRules.bulkPut(SEED_CATEGORY_RULES);
     },
   );
 }

--- a/src/dev/seedData.ts
+++ b/src/dev/seedData.ts
@@ -1,0 +1,137 @@
+import type { Category, CategoryRule, PaymentFile } from "../data";
+
+const FOOD_ID = "seed-cat-food";
+const TRANSPORT_ID = "seed-cat-transport";
+const ENTERTAINMENT_ID = "seed-cat-entertainment";
+const DAILY_ID = "seed-cat-daily";
+const TELECOM_ID = "seed-cat-telecom";
+const MEDICAL_ID = "seed-cat-medical";
+
+export const SEED_CATEGORIES: Category[] = [
+  { id: FOOD_ID, name: "食費", order: 0 },
+  { id: TRANSPORT_ID, name: "交通費", order: 1 },
+  { id: ENTERTAINMENT_ID, name: "娯楽費", order: 2 },
+  { id: DAILY_ID, name: "日用品", order: 3 },
+  { id: TELECOM_ID, name: "通信費", order: 4 },
+  { id: MEDICAL_ID, name: "医療費", order: 5 },
+];
+
+export const SEED_CATEGORY_RULES: CategoryRule[] = [
+  {
+    id: "seed-rule-food-1",
+    categoryId: FOOD_ID,
+    pattern: "スーパー",
+    order: 0,
+  },
+  {
+    id: "seed-rule-food-2",
+    categoryId: FOOD_ID,
+    pattern: "コンビニ",
+    order: 1,
+  },
+  { id: "seed-rule-food-3", categoryId: FOOD_ID, pattern: "カフェ", order: 2 },
+  {
+    id: "seed-rule-food-4",
+    categoryId: FOOD_ID,
+    pattern: "レストラン",
+    order: 3,
+  },
+  {
+    id: "seed-rule-transport-1",
+    categoryId: TRANSPORT_ID,
+    pattern: "交通系IC",
+    order: 0,
+  },
+  {
+    id: "seed-rule-transport-2",
+    categoryId: TRANSPORT_ID,
+    pattern: "タクシー",
+    order: 1,
+  },
+  {
+    id: "seed-rule-entertainment-1",
+    categoryId: ENTERTAINMENT_ID,
+    pattern: "Netflix",
+    order: 0,
+  },
+  {
+    id: "seed-rule-entertainment-2",
+    categoryId: ENTERTAINMENT_ID,
+    pattern: "Amazon Prime",
+    order: 1,
+  },
+  {
+    id: "seed-rule-entertainment-3",
+    categoryId: ENTERTAINMENT_ID,
+    pattern: "Spotify",
+    order: 2,
+  },
+  {
+    id: "seed-rule-daily-1",
+    categoryId: DAILY_ID,
+    pattern: "ドラッグストア",
+    order: 0,
+  },
+  {
+    id: "seed-rule-daily-2",
+    categoryId: DAILY_ID,
+    pattern: "UNIQLO",
+    order: 1,
+  },
+  {
+    id: "seed-rule-telecom-1",
+    categoryId: TELECOM_ID,
+    pattern: "NTTドコモ",
+    order: 0,
+  },
+  {
+    id: "seed-rule-medical-1",
+    categoryId: MEDICAL_ID,
+    pattern: "病院",
+    order: 0,
+  },
+  {
+    id: "seed-rule-medical-2",
+    categoryId: MEDICAL_ID,
+    pattern: "薬局",
+    order: 1,
+  },
+];
+
+function makePayments(year: number, month: number): PaymentFile["payments"] {
+  const mm = String(month).padStart(2, "0");
+  const d = (day: number) => `${year}-${mm}-${String(day).padStart(2, "0")}`;
+
+  return [
+    { name: "スーパーマーケット", date: d(2), price: 3200, count: 1 },
+    { name: "コンビニ セブン-イレブン", date: d(3), price: 850, count: 1 },
+    { name: "交通系IC チャージ", date: d(5), price: 3000, count: 1 },
+    { name: "カフェ スターバックス", date: d(6), price: 620, count: 1 },
+    {
+      name: "ドラッグストア マツモトキヨシ",
+      date: d(8),
+      price: 1540,
+      count: 1,
+    },
+    { name: "レストラン 丸亀製麺", date: d(10), price: 780, count: 1 },
+    { name: "Netflix", date: d(12), price: 1490, count: 1 },
+    { name: "スーパーマーケット", date: d(14), price: 4100, count: 1 },
+    { name: "タクシー GO", date: d(15), price: 1230, count: 1 },
+    { name: "Amazon Prime", date: d(16), price: 600, count: 1 },
+    { name: "コンビニ ファミリーマート", date: d(18), price: 420, count: 1 },
+    { name: "UNIQLO", date: d(20), price: 5490, count: 1 },
+    { name: "NTTドコモ", date: d(22), price: 4180, count: 1 },
+    { name: "カフェ ドトール", date: d(24), price: 480, count: 1 },
+    { name: "スーパーマーケット", date: d(26), price: 2980, count: 1 },
+    { name: "Spotify", date: d(28), price: 980, count: 1 },
+  ];
+}
+
+export const SEED_PAYMENT_FILES: PaymentFile[] = [
+  { fileName: "2025-11.csv", payments: makePayments(2025, 11) },
+  { fileName: "2025-12.csv", payments: makePayments(2025, 12) },
+  { fileName: "2026-01.csv", payments: makePayments(2026, 1) },
+  { fileName: "2026-02.csv", payments: makePayments(2026, 2) },
+  { fileName: "2026-03.csv", payments: makePayments(2026, 3) },
+  { fileName: "2026-04.csv", payments: makePayments(2026, 4) },
+];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
+import { seedIfNeeded } from "./dev/seed";
 import "./index.css";
 
 const router = createRouter({ routeTree });
@@ -12,12 +13,14 @@ declare module "@tanstack/react-router" {
   }
 }
 
-const rootElement = document.getElementById("root")!;
-if (!rootElement.innerHTML) {
-  const root = ReactDOM.createRoot(rootElement);
-  root.render(
-    <StrictMode>
-      <RouterProvider router={router} />
-    </StrictMode>,
-  );
-}
+void seedIfNeeded().then(() => {
+  const rootElement = document.getElementById("root")!;
+  if (!rootElement.innerHTML) {
+    const root = ReactDOM.createRoot(rootElement);
+    root.render(
+      <StrictMode>
+        <RouterProvider router={router} />
+      </StrictMode>,
+    );
+  }
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ declare module "@tanstack/react-router" {
   }
 }
 
-void seedIfNeeded().then(() => {
+const renderApp = () => {
   const rootElement = document.getElementById("root")!;
   if (!rootElement.innerHTML) {
     const root = ReactDOM.createRoot(rootElement);
@@ -23,4 +23,9 @@ void seedIfNeeded().then(() => {
       </StrictMode>,
     );
   }
+};
+
+void seedIfNeeded().then(renderApp, (err) => {
+  console.error("seed failed:", err);
+  renderApp();
 });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ENABLE_SEED?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "buildCommand": "[ \"$VERCEL_ENV\" = 'preview' ] && VITE_ENABLE_SEED=true npm run build || npm run build"
 }


### PR DESCRIPTION
close #135

## 概要

Vercel の PR プレビュー環境に初回アクセスした際、IndexedDB が空であれば支払いデータ・カテゴリ・カテゴリルールのダミーデータを自動投入する機能を追加する。

## 変更内容

- `src/dev/seedData.ts`: ダミーデータを定義（6ヶ月分の PaymentFile・6カテゴリ・14件のカテゴリルール）
- `src/dev/seed.ts`: シード実行ロジック（環境変数チェック・IndexedDB 空判定・冪等な bulkPut）
- `src/main.tsx`: アプリ起動前に `seedIfNeeded()` を実行するよう変更。失敗時もアプリを起動し続けるフォールバックを追加
- `src/vite-env.d.ts`: `VITE_ENABLE_SEED` の型定義を追加

## 動作

- `VITE_ENABLE_SEED=true` のとき、かつ `paymentFiles` テーブルが空のとき、ダミーデータを自動投入する
- `VITE_ENABLE_SEED` が未設定（本番・ローカル開発）の場合は何もしない
- `bulkPut` を使用しているため、カテゴリだけ残った状態でファイルを全削除した場合など、テーブル間の状態不一致でも冪等に動作する

## Vercel 設定

Vercel ダッシュボードのプロジェクト設定 → Environment Variables にて、**Preview** スコープのみに `VITE_ENABLE_SEED=true` を追加してください。

## ローカルでの確認手順

```bash
VITE_ENABLE_SEED=true npm run dev
```

ブラウザでアプリを開くと、CSV をアップロードせずに月別グラフ・カテゴリ別内訳が表示されることを確認する。