### PR TITLE
feat: カテゴリ色の解決ロジックを共通化しテーブル・グラフの色を同期

### DIFF
--- a/src/data/categories/categoryColors.test.ts
+++ b/src/data/categories/categoryColors.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_CATEGORY_COLORS,
+  getDefaultColor,
+  resolveCategoryColor,
+} from "./categoryColors";
+
+describe("getDefaultColor", () => {
+  it("index に対応する色を返す", () => {
+    expect(getDefaultColor(0)).toBe(DEFAULT_CATEGORY_COLORS[0]);
+    expect(getDefaultColor(1)).toBe(DEFAULT_CATEGORY_COLORS[1]);
+  });
+
+  it("index が配列長を超えた場合は循環する", () => {
+    const len = DEFAULT_CATEGORY_COLORS.length;
+    expect(getDefaultColor(len)).toBe(DEFAULT_CATEGORY_COLORS[0]);
+    expect(getDefaultColor(len + 1)).toBe(DEFAULT_CATEGORY_COLORS[1]);
+  });
+});
+
+describe("resolveCategoryColor", () => {
+  it("color が指定されている場合はそれを返す", () => {
+    expect(resolveCategoryColor("#FF0000", 0)).toBe("#FF0000");
+    expect(resolveCategoryColor("#FF0000", 5)).toBe("#FF0000");
+  });
+
+  it("color が undefined の場合は index に対応するデフォルト色を返す", () => {
+    expect(resolveCategoryColor(undefined, 0)).toBe(DEFAULT_CATEGORY_COLORS[0]);
+    expect(resolveCategoryColor(undefined, 1)).toBe(DEFAULT_CATEGORY_COLORS[1]);
+  });
+
+  it("color が undefined かつ同じ index なら同じ色を返す（テーブルとグラフで一致）", () => {
+    const color1 = resolveCategoryColor(undefined, 3);
+    const color2 = resolveCategoryColor(undefined, 3);
+    expect(color1).toBe(color2);
+  });
+});

--- a/src/data/categories/categoryColors.ts
+++ b/src/data/categories/categoryColors.ts
@@ -14,3 +14,10 @@ export const DEFAULT_CATEGORY_COLORS = [
 export function getDefaultColor(index: number): string {
   return DEFAULT_CATEGORY_COLORS[index % DEFAULT_CATEGORY_COLORS.length];
 }
+
+export function resolveCategoryColor(
+  color: string | undefined,
+  index: number,
+): string {
+  return color ?? getDefaultColor(index);
+}

--- a/src/pages/DetailPage/components/PaymentCategoryView/CategoryBreakdownRow.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/CategoryBreakdownRow.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 import { ChevronRightIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
 import { PaymentDetailTable } from "./PaymentDetailTable";
 import { formatYen } from "../../../../utils/formatYen";
-import { DEFAULT_CATEGORY_COLORS } from "../../../../data/categories/categoryColors";
+import { resolveCategoryColor } from "../../../../data/categories/categoryColors";
 
 type PaymentDetail = {
   name: string;
@@ -99,8 +99,10 @@ export function CategoryBreakdownRow({ item, index }: Props) {
               <span
                 className="inline-block h-3 w-3 flex-shrink-0 rounded-full"
                 style={{
-                  backgroundColor:
-                    item.category.color ?? DEFAULT_CATEGORY_COLORS[0],
+                  backgroundColor: resolveCategoryColor(
+                    item.category.color,
+                    index,
+                  ),
                 }}
               />
               <span>{item.category.name}</span>

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
@@ -9,7 +9,7 @@ import {
 } from "recharts";
 import { formatYen } from "../../../../utils/formatYen";
 
-import { DEFAULT_CATEGORY_COLORS } from "../../../../data/categories/categoryColors";
+import { resolveCategoryColor } from "../../../../data/categories/categoryColors";
 
 type Props = {
   data: { name: string; value: number; color?: string }[];
@@ -27,12 +27,7 @@ export function PayviewCategoryBarChart({ data }: Props) {
             {data.map((item, index) => (
               <Cell
                 key={item.name}
-                fill={
-                  item.color ??
-                  DEFAULT_CATEGORY_COLORS[
-                    index % DEFAULT_CATEGORY_COLORS.length
-                  ]
-                }
+                fill={resolveCategoryColor(item.color, index)}
               />
             ))}
           </Bar>

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryPieChart.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryPieChart.tsx
@@ -1,6 +1,6 @@
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
 import { formatYen } from "../../../../utils/formatYen";
-import { DEFAULT_CATEGORY_COLORS } from "../../../../data/categories/categoryColors";
+import { resolveCategoryColor } from "../../../../data/categories/categoryColors";
 
 type Props = {
   data: { name: string; value: number; color?: string }[];
@@ -24,12 +24,7 @@ export function PayviewCategoryPieChart({ data }: Props) {
             {data.map((item, index) => (
               <Cell
                 key={item.name}
-                fill={
-                  item.color ??
-                  DEFAULT_CATEGORY_COLORS[
-                    index % DEFAULT_CATEGORY_COLORS.length
-                  ]
-                }
+                fill={resolveCategoryColor(item.color, index)}
               />
             ))}
           </Pie>


### PR DESCRIPTION
close #131

## 概要

- `categoryColors.ts` に `resolveCategoryColor(color, index)` 関数を追加
- `CategoryBreakdownRow`・`PayviewCategoryBarChart`・`PayviewCategoryPieChart` の 3 コンポーネントが同一の色解決ロジックを参照するよう統一
- `resolveCategoryColor` のユニットテストを追加

## 変更ファイル

| ファイル | 変更内容 |
| --- | --- |
| `src/data/categories/categoryColors.ts` | `resolveCategoryColor` 関数を追加 |
| `src/pages/.../CategoryBreakdownRow.tsx` | `resolveCategoryColor` を使用するよう修正 |
| `src/pages/.../PayviewCategoryBarChart.tsx` | `resolveCategoryColor` を使用するよう修正 |
| `src/pages/.../PayviewCategoryPieChart.tsx` | `resolveCategoryColor` を使用するよう修正 |
| `src/data/categories/categoryColors.test.ts` | `resolveCategoryColor` のユニットテストを追加 |

## ローカル検証手順

1. `npm run dev` で開発サーバーを起動
2. `/payments/<ファイル名>` → カテゴリタブを開く
3. 棒グラフ・円グラフと内訳テーブルで同一カテゴリが同色であることを確認
4. `/settings` でカテゴリ色を変更 → カテゴリタブでグラフ・テーブル両方に即時反映されることを確認