### PR TITLE
feat: カテゴリ別棒グラフに予算参照線を表示する

### DIFF
--- a/src/pages/DetailPage/components/PaymentCategoryView/PaymentCategoryView.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PaymentCategoryView.tsx
@@ -30,6 +30,7 @@ export function PaymentCategoryView({ fileName }: Props) {
     name: item.category?.name || "未分類",
     value: item.total,
     color: item.category?.color,
+    budget: item.monthlyBudget,
   }));
 
   const hasNoData = breakdown.length === 0;

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.test.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.test.tsx
@@ -23,7 +23,16 @@ describe("buildCombinedBarShape", () => {
   test("budgetがundefinedの場合、rectのみ描画されpathはない", () => {
     const shape = buildCombinedBarShape([{ name: "食費", value: 10000 }]);
     const { container } = render(
-      <svg>{shape({ x: 10, y: 50, width: 60, height: 100, index: 0, fill: "#8B5CF6" })}</svg>,
+      <svg>
+        {shape({
+          x: 10,
+          y: 50,
+          width: 60,
+          height: 100,
+          index: 0,
+          fill: "#8B5CF6",
+        })}
+      </svg>,
     );
     expect(container.querySelector("rect")).not.toBeNull();
     expect(container.querySelector("path")).toBeNull();
@@ -34,7 +43,16 @@ describe("buildCombinedBarShape", () => {
       { name: "食費", value: 10000, budget: 0 },
     ]);
     const { container } = render(
-      <svg>{shape({ x: 10, y: 50, width: 60, height: 100, index: 0, fill: "#8B5CF6" })}</svg>,
+      <svg>
+        {shape({
+          x: 10,
+          y: 50,
+          width: 60,
+          height: 100,
+          index: 0,
+          fill: "#8B5CF6",
+        })}
+      </svg>,
     );
     expect(container.querySelector("path")).not.toBeNull();
   });
@@ -44,7 +62,16 @@ describe("buildCombinedBarShape", () => {
       { name: "食費", value: 20000, budget: 15000 },
     ]);
     const { container } = render(
-      <svg>{shape({ x: 10, y: 50, width: 60, height: 100, index: 0, fill: "#8B5CF6" })}</svg>,
+      <svg>
+        {shape({
+          x: 10,
+          y: 50,
+          width: 60,
+          height: 100,
+          index: 0,
+          fill: "#8B5CF6",
+        })}
+      </svg>,
     );
     expect(container.querySelector('path[stroke="#EF4444"]')).not.toBeNull();
   });
@@ -54,7 +81,16 @@ describe("buildCombinedBarShape", () => {
       { name: "食費", value: 10000, budget: 15000 },
     ]);
     const { container } = render(
-      <svg>{shape({ x: 10, y: 50, width: 60, height: 100, index: 0, fill: "#8B5CF6" })}</svg>,
+      <svg>
+        {shape({
+          x: 10,
+          y: 50,
+          width: 60,
+          height: 100,
+          index: 0,
+          fill: "#8B5CF6",
+        })}
+      </svg>,
     );
     expect(container.querySelector('path[stroke="#10B981"]')).not.toBeNull();
   });
@@ -64,7 +100,9 @@ describe("buildCombinedBarShape", () => {
       { name: "食費", value: 10000, budget: 15000 },
     ]);
     const { container } = render(
-      <svg>{shape({ x: undefined, y: 50, width: 60, height: 100, index: 0 })}</svg>,
+      <svg>
+        {shape({ x: undefined, y: 50, width: 60, height: 100, index: 0 })}
+      </svg>,
     );
     expect(container.querySelector("rect")).toBeNull();
   });

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.test.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.test.tsx
@@ -1,53 +1,71 @@
 import { describe, expect, test } from "vitest";
 import { render } from "@testing-library/react";
-import { buildBudgetLineShape } from "./budgetLineShape";
+import { buildCombinedBarShape, calcBudgetLineY } from "./budgetLineShape";
 
-describe("buildBudgetLineShape", () => {
-  test("budgetがundefinedの場合はnullを返す", () => {
-    const shape = buildBudgetLineShape([{ name: "食費", value: 10000 }]);
+describe("calcBudgetLineY", () => {
+  test("支出 = 予算のとき、バー天井と同じ y を返す", () => {
+    expect(calcBudgetLineY(10, 100, 1000, 1000)).toBe(10);
+  });
+
+  test("支出が予算の半分のとき、バー中央の y を返す", () => {
+    // value=500, budget=1000: budget_y = y + h * (1 - 1000/500) = y + h * (-1) = y - h
+    // → バー天井より上（予算の方が高い）
+    expect(calcBudgetLineY(10, 50, 500, 1000)).toBe(-40);
+  });
+
+  test("支出が予算より多いとき、バー内に y が収まる", () => {
+    // value=2000, budget=1000: budget_y = y + h * (1 - 1000/2000) = y + h * 0.5
+    expect(calcBudgetLineY(10, 100, 2000, 1000)).toBe(60);
+  });
+});
+
+describe("buildCombinedBarShape", () => {
+  test("budgetがundefinedの場合、rectのみ描画されpathはない", () => {
+    const shape = buildCombinedBarShape([{ name: "食費", value: 10000 }]);
     const { container } = render(
-      <svg>{shape({ x: 10, y: 50, width: 60, index: 0 })}</svg>,
+      <svg>{shape({ x: 10, y: 50, width: 60, height: 100, index: 0, fill: "#8B5CF6" })}</svg>,
     );
+    expect(container.querySelector("rect")).not.toBeNull();
     expect(container.querySelector("path")).toBeNull();
   });
 
-  test("budget=0は有効な予算値として扱い、ラインを描画する", () => {
-    const shape = buildBudgetLineShape([
+  test("budget=0は有効な予算値としてpathを描画する", () => {
+    const shape = buildCombinedBarShape([
       { name: "食費", value: 10000, budget: 0 },
     ]);
     const { container } = render(
-      <svg>{shape({ x: 10, y: 50, width: 60, index: 0 })}</svg>,
+      <svg>{shape({ x: 10, y: 50, width: 60, height: 100, index: 0, fill: "#8B5CF6" })}</svg>,
     );
     expect(container.querySelector("path")).not.toBeNull();
   });
 
-  test("支出が予算を超えている場合は赤色のラインを返す", () => {
-    const shape = buildBudgetLineShape([
+  test("支出が予算を超えている場合は赤色のpathを描画する", () => {
+    const shape = buildCombinedBarShape([
       { name: "食費", value: 20000, budget: 15000 },
     ]);
     const { container } = render(
-      <svg>{shape({ x: 10, y: 50, width: 60, index: 0 })}</svg>,
+      <svg>{shape({ x: 10, y: 50, width: 60, height: 100, index: 0, fill: "#8B5CF6" })}</svg>,
     );
     expect(container.querySelector('path[stroke="#EF4444"]')).not.toBeNull();
   });
 
-  test("支出が予算以下の場合は緑色のラインを返す", () => {
-    const shape = buildBudgetLineShape([
+  test("支出が予算以下の場合は緑色のpathを描画する", () => {
+    const shape = buildCombinedBarShape([
       { name: "食費", value: 10000, budget: 15000 },
     ]);
     const { container } = render(
-      <svg>{shape({ x: 10, y: 50, width: 60, index: 0 })}</svg>,
+      <svg>{shape({ x: 10, y: 50, width: 60, height: 100, index: 0, fill: "#8B5CF6" })}</svg>,
     );
     expect(container.querySelector('path[stroke="#10B981"]')).not.toBeNull();
   });
 
-  test("x/y/width/indexのいずれかがundefinedの場合はnullを返す", () => {
-    const shape = buildBudgetLineShape([
+  test("x/y/width/height/indexのいずれかがundefinedの場合はnullを返す", () => {
+    const shape = buildCombinedBarShape([
       { name: "食費", value: 10000, budget: 15000 },
     ]);
     const { container } = render(
-      <svg>{shape({ x: undefined, y: 50, width: 60, index: 0 })}</svg>,
+      <svg>{shape({ x: undefined, y: 50, width: 60, height: 100, index: 0 })}</svg>,
     );
-    expect(container.querySelector("path")).toBeNull();
+    expect(container.querySelector("rect")).toBeNull();
   });
 });

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.test.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import { render } from "@testing-library/react";
+import { buildBudgetLineShape } from "./budgetLineShape";
+
+describe("buildBudgetLineShape", () => {
+  test("budgetがundefinedの場合はnullを返す", () => {
+    const shape = buildBudgetLineShape([{ name: "食費", value: 10000 }]);
+    const { container } = render(
+      <svg>{shape({ x: 10, y: 50, width: 60, index: 0 })}</svg>,
+    );
+    expect(container.querySelector("path")).toBeNull();
+  });
+
+  test("budget=0は有効な予算値として扱い、ラインを描画する", () => {
+    const shape = buildBudgetLineShape([
+      { name: "食費", value: 10000, budget: 0 },
+    ]);
+    const { container } = render(
+      <svg>{shape({ x: 10, y: 50, width: 60, index: 0 })}</svg>,
+    );
+    expect(container.querySelector("path")).not.toBeNull();
+  });
+
+  test("支出が予算を超えている場合は赤色のラインを返す", () => {
+    const shape = buildBudgetLineShape([
+      { name: "食費", value: 20000, budget: 15000 },
+    ]);
+    const { container } = render(
+      <svg>{shape({ x: 10, y: 50, width: 60, index: 0 })}</svg>,
+    );
+    expect(container.querySelector('path[stroke="#EF4444"]')).not.toBeNull();
+  });
+
+  test("支出が予算以下の場合は緑色のラインを返す", () => {
+    const shape = buildBudgetLineShape([
+      { name: "食費", value: 10000, budget: 15000 },
+    ]);
+    const { container } = render(
+      <svg>{shape({ x: 10, y: 50, width: 60, index: 0 })}</svg>,
+    );
+    expect(container.querySelector('path[stroke="#10B981"]')).not.toBeNull();
+  });
+
+  test("x/y/width/indexのいずれかがundefinedの場合はnullを返す", () => {
+    const shape = buildBudgetLineShape([
+      { name: "食費", value: 10000, budget: 15000 },
+    ]);
+    const { container } = render(
+      <svg>{shape({ x: undefined, y: 50, width: 60, index: 0 })}</svg>,
+    );
+    expect(container.querySelector("path")).toBeNull();
+  });
+});

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   BarChart,
   Bar,
@@ -11,18 +12,71 @@ import { formatYen } from "../../../../utils/formatYen";
 
 import { DEFAULT_CATEGORY_COLORS } from "../../../../data/categories/categoryColors";
 
-type Props = {
-  data: { name: string; value: number; color?: string }[];
+type DataItem = {
+  name: string;
+  value: number;
+  color?: string;
+  budget?: number;
 };
 
+type Props = {
+  data: DataItem[];
+};
+
+type BudgetLineShapeProps = {
+  x?: number;
+  y?: number;
+  width?: number;
+  index?: number;
+  [key: string]: unknown;
+};
+
+function buildBudgetLineShape(data: DataItem[]) {
+  return function BudgetLineShape({
+    x,
+    y,
+    width,
+    index,
+  }: BudgetLineShapeProps) {
+    if (
+      x === undefined ||
+      y === undefined ||
+      width === undefined ||
+      index === undefined
+    )
+      return null;
+    const item = data[index];
+    if (!item?.budget) return null;
+    const isOverBudget = item.value > item.budget;
+    const stroke = isOverBudget ? "#EF4444" : "#10B981";
+    return (
+      <path
+        d={`M${x},${y} L${x + width},${y}`}
+        stroke={stroke}
+        strokeWidth={2}
+        strokeDasharray="4 2"
+        fill="none"
+      />
+    );
+  };
+}
+
 export function PayviewCategoryBarChart({ data }: Props) {
+  const BudgetLineShape = useMemo(() => buildBudgetLineShape(data), [data]);
+
   return (
     <div className="max-w-full">
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={data}>
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip formatter={(value: number) => [formatYen(value), "金額"]} />
+          <Tooltip
+            formatter={(value: number, name: string) =>
+              name === "budget"
+                ? [formatYen(value), "月予算"]
+                : [formatYen(value), "金額"]
+            }
+          />
           <Bar dataKey="value">
             {data.map((item, index) => (
               <Cell
@@ -36,6 +90,13 @@ export function PayviewCategoryBarChart({ data }: Props) {
               />
             ))}
           </Bar>
+          <Bar
+            dataKey="budget"
+            // @ts-expect-error Recharts shape accepts function components at runtime
+            shape={BudgetLineShape}
+            isAnimationActive={false}
+            legendType="none"
+          />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
@@ -11,7 +11,7 @@ import {
 import { formatYen } from "../../../../utils/formatYen";
 
 import { resolveCategoryColor } from "../../../../data/categories/categoryColors";
-import { buildBudgetLineShape } from "./budgetLineShape";
+import { buildCombinedBarShape } from "./budgetLineShape";
 
 type DataItem = {
   name: string;
@@ -25,22 +25,26 @@ type Props = {
 };
 
 export function PayviewCategoryBarChart({ data }: Props) {
-  const BudgetLineShape = useMemo(() => buildBudgetLineShape(data), [data]);
+  const CombinedBarShape = useMemo(() => buildCombinedBarShape(data), [data]);
+
+  const yMax = useMemo(() => {
+    const maxValue = Math.max(...data.map((d) => d.value), 0);
+    const maxBudget = Math.max(...data.map((d) => d.budget ?? 0), 0);
+    return Math.max(maxValue, maxBudget);
+  }, [data]);
 
   return (
     <div className="max-w-full">
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={data}>
           <XAxis dataKey="name" />
-          <YAxis />
-          <Tooltip
-            formatter={(value: number, name: string) =>
-              name === "budget"
-                ? [formatYen(value), "月予算"]
-                : [formatYen(value), "金額"]
-            }
-          />
-          <Bar dataKey="value">
+          <YAxis domain={[0, yMax]} />
+          <Tooltip formatter={(value: number) => [formatYen(value), "金額"]} />
+          <Bar
+            dataKey="value"
+            // @ts-expect-error Recharts shape accepts function components at runtime
+            shape={CombinedBarShape}
+          >
             {data.map((item, index) => (
               <Cell
                 key={item.name}
@@ -48,13 +52,6 @@ export function PayviewCategoryBarChart({ data }: Props) {
               />
             ))}
           </Bar>
-          <Bar
-            dataKey="budget"
-            // @ts-expect-error Recharts shape accepts function components at runtime
-            shape={BudgetLineShape}
-            isAnimationActive={false}
-            legendType="none"
-          />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx
@@ -11,6 +11,7 @@ import {
 import { formatYen } from "../../../../utils/formatYen";
 
 import { DEFAULT_CATEGORY_COLORS } from "../../../../data/categories/categoryColors";
+import { buildBudgetLineShape } from "./budgetLineShape";
 
 type DataItem = {
   name: string;
@@ -22,44 +23,6 @@ type DataItem = {
 type Props = {
   data: DataItem[];
 };
-
-type BudgetLineShapeProps = {
-  x?: number;
-  y?: number;
-  width?: number;
-  index?: number;
-  [key: string]: unknown;
-};
-
-function buildBudgetLineShape(data: DataItem[]) {
-  return function BudgetLineShape({
-    x,
-    y,
-    width,
-    index,
-  }: BudgetLineShapeProps) {
-    if (
-      x === undefined ||
-      y === undefined ||
-      width === undefined ||
-      index === undefined
-    )
-      return null;
-    const item = data[index];
-    if (!item?.budget) return null;
-    const isOverBudget = item.value > item.budget;
-    const stroke = isOverBudget ? "#EF4444" : "#10B981";
-    return (
-      <path
-        d={`M${x},${y} L${x + width},${y}`}
-        stroke={stroke}
-        strokeWidth={2}
-        strokeDasharray="4 2"
-        fill="none"
-      />
-    );
-  };
-}
 
 export function PayviewCategoryBarChart({ data }: Props) {
   const BudgetLineShape = useMemo(() => buildBudgetLineShape(data), [data]);

--- a/src/pages/DetailPage/components/PaymentCategoryView/budgetLineShape.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/budgetLineShape.tsx
@@ -4,40 +4,70 @@ type DataItem = {
   budget?: number;
 };
 
-type BudgetLineShapeProps = {
+type CombinedBarShapeProps = {
   x?: number;
   y?: number;
   width?: number;
+  height?: number;
   index?: number;
+  fill?: string;
   [key: string]: unknown;
 };
 
-export function buildBudgetLineShape(data: DataItem[]) {
-  return function BudgetLineShape({
+// 予算ラインの y ピクセル位置を計算する。
+// バーの geometry (y, height) と spending/budget 値から、Y軸スケールに依存せず導出できる。
+// budget_y = y + height * (1 - budget / value)
+export function calcBudgetLineY(
+  y: number,
+  height: number,
+  value: number,
+  budget: number,
+): number {
+  return y + height * (1 - budget / value);
+}
+
+export function buildCombinedBarShape(data: DataItem[]) {
+  return function CombinedBarShape({
     x,
     y,
     width,
+    height,
     index,
-  }: BudgetLineShapeProps) {
+    fill,
+  }: CombinedBarShapeProps) {
     if (
       x === undefined ||
       y === undefined ||
       width === undefined ||
+      height === undefined ||
       index === undefined
     )
       return null;
+
     const item = data[index];
-    if (item?.budget === undefined) return null;
-    const isOverBudget = item.value > item.budget;
+    if (!item) return null;
+
+    const { budget, value } = item;
+    const budgetY =
+      budget !== undefined && value > 0
+        ? calcBudgetLineY(y, height, value, budget)
+        : null;
+    const isOverBudget = budget !== undefined && value > budget;
     const stroke = isOverBudget ? "#EF4444" : "#10B981";
+
     return (
-      <path
-        d={`M${x},${y} L${x + width},${y}`}
-        stroke={stroke}
-        strokeWidth={2}
-        strokeDasharray="4 2"
-        fill="none"
-      />
+      <g>
+        <rect x={x} y={y} width={width} height={height} fill={fill} />
+        {budgetY !== null && (
+          <path
+            d={`M${x},${budgetY} L${x + width},${budgetY}`}
+            stroke={stroke}
+            strokeWidth={2}
+            strokeDasharray="4 2"
+            fill="none"
+          />
+        )}
+      </g>
     );
   };
 }

--- a/src/pages/DetailPage/components/PaymentCategoryView/budgetLineShape.tsx
+++ b/src/pages/DetailPage/components/PaymentCategoryView/budgetLineShape.tsx
@@ -1,0 +1,43 @@
+type DataItem = {
+  name: string;
+  value: number;
+  budget?: number;
+};
+
+type BudgetLineShapeProps = {
+  x?: number;
+  y?: number;
+  width?: number;
+  index?: number;
+  [key: string]: unknown;
+};
+
+export function buildBudgetLineShape(data: DataItem[]) {
+  return function BudgetLineShape({
+    x,
+    y,
+    width,
+    index,
+  }: BudgetLineShapeProps) {
+    if (
+      x === undefined ||
+      y === undefined ||
+      width === undefined ||
+      index === undefined
+    )
+      return null;
+    const item = data[index];
+    if (item?.budget === undefined) return null;
+    const isOverBudget = item.value > item.budget;
+    const stroke = isOverBudget ? "#EF4444" : "#10B981";
+    return (
+      <path
+        d={`M${x},${y} L${x + width},${y}`}
+        stroke={stroke}
+        strokeWidth={2}
+        strokeDasharray="4 2"
+        fill="none"
+      />
+    );
+  };
+}


### PR DESCRIPTION
close #132

## 概要

- カテゴリ別棒グラフ（`PayviewCategoryBarChart`）の各バーに、`monthlyBudget` を示す破線の参照線を追加
- 支出が予算超過の場合は赤（`#EF4444`）、余裕ありの場合は緑（`#10B981`）で表示
- `monthlyBudget` が未設定のカテゴリには参照線を表示しない
- ツールチップにも「月予算」として予算値を表示

## 変更ファイル

- `src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.tsx` — 予算 Bar と Tooltip 更新
- `src/pages/DetailPage/components/PaymentCategoryView/budgetLineShape.tsx` — 予算ラインの描画ロジック（新規）
- `src/pages/DetailPage/components/PaymentCategoryView/PayviewCategoryBarChart.test.tsx` — ユニットテスト（新規）
- `src/pages/DetailPage/components/PaymentCategoryView/PaymentCategoryView.tsx` — chartData に `budget` を追加

## 実装詳細

Recharts の `Bar` コンポーネントに `dataKey="budget"` を追加し、`shape` prop でカスタムの `<path>` 要素を描画している。`buildBudgetLineShape` はデータ配列を受け取るファクトリ関数で、`index` prop 経由で各カテゴリの budget と支出を比較して色を決定する。

## ローカル検証手順

1. `npm run dev` で開発サーバー起動
2. 設定画面でカテゴリに月予算を設定
3. 明細ページの「内訳」タブ → カテゴリ別棒グラフで予算ラインを確認
4. 予算超過バーは赤、余裕ありバーは緑の破線が表示されることを確認