### PR TITLE
feat: 支払い詳細画面にCSVエクスポート機能を追加

### DIFF
--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -12,8 +12,9 @@ type Props = {
 export function DetailPage({ fileName, activeTab }: Props) {
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between">
-        <Tabs fileName={fileName} activeTab={activeTab} />
+      <Tabs fileName={fileName} activeTab={activeTab} />
+
+      <div className="flex justify-end">
         <CsvExportButton fileName={fileName} />
       </div>
 

--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -2,6 +2,7 @@ import { Tabs } from "./components/Tabs";
 import { Activity } from "react";
 import { PaymentView } from "./components/PaymentView/PaymentView";
 import { PaymentCategoryView } from "./components/PaymentCategoryView/PaymentCategoryView";
+import { CsvExportButton } from "./components/CsvExportButton";
 
 type Props = {
   fileName: string;
@@ -11,7 +12,10 @@ type Props = {
 export function DetailPage({ fileName, activeTab }: Props) {
   return (
     <div className="flex flex-col gap-6">
-      <Tabs fileName={fileName} activeTab={activeTab} />
+      <div className="flex items-center justify-between">
+        <Tabs fileName={fileName} activeTab={activeTab} />
+        <CsvExportButton fileName={fileName} />
+      </div>
 
       <Activity mode={activeTab === "breakdown" ? "visible" : "hidden"}>
         <PaymentCategoryView fileName={fileName} />

--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -2,7 +2,6 @@ import { Tabs } from "./components/Tabs";
 import { Activity } from "react";
 import { PaymentView } from "./components/PaymentView/PaymentView";
 import { PaymentCategoryView } from "./components/PaymentCategoryView/PaymentCategoryView";
-import { CsvExportButton } from "./components/CsvExportButton";
 
 type Props = {
   fileName: string;
@@ -13,10 +12,6 @@ export function DetailPage({ fileName, activeTab }: Props) {
   return (
     <div className="flex flex-col gap-6">
       <Tabs fileName={fileName} activeTab={activeTab} />
-
-      <div className="flex justify-end">
-        <CsvExportButton fileName={fileName} />
-      </div>
 
       <Activity mode={activeTab === "breakdown" ? "visible" : "hidden"}>
         <PaymentCategoryView fileName={fileName} />

--- a/src/pages/DetailPage/components/CsvExportButton.tsx
+++ b/src/pages/DetailPage/components/CsvExportButton.tsx
@@ -1,0 +1,42 @@
+import { usePaymentsByCategory } from "../../../data/payments";
+import { downloadCsv } from "../../../utils/downloadCsv";
+
+type Props = {
+  fileName: string;
+};
+
+export function CsvExportButton({ fileName }: Props) {
+  const result = usePaymentsByCategory({ fileName });
+
+  const handleExport = () => {
+    if (result.status !== "completed") return;
+
+    const rows: string[][] = [["日付", "金額", "カテゴリ", "説明"]];
+
+    for (const item of result.breakdown) {
+      const categoryName = item.category?.name ?? "未分類";
+      for (const payment of item.payments) {
+        rows.push([
+          payment.date,
+          String(payment.price),
+          categoryName,
+          payment.name,
+        ]);
+      }
+    }
+
+    const baseName = fileName.replace(/\.[^.]+$/, "");
+    downloadCsv(`${baseName}.csv`, rows);
+  };
+
+  return (
+    <button
+      type="button"
+      className="btn btn-outline btn-sm"
+      onClick={handleExport}
+      disabled={result.status !== "completed"}
+    >
+      CSVエクスポート
+    </button>
+  );
+}

--- a/src/pages/DetailPage/components/Tabs.tsx
+++ b/src/pages/DetailPage/components/Tabs.tsx
@@ -2,6 +2,7 @@ import { Link, Outlet } from "@tanstack/react-router";
 import clsx from "clsx";
 import { FileNavigation } from "./FileNavigation";
 import { TotalAmount } from "./TotalAmount";
+import { CsvExportButton } from "./CsvExportButton";
 
 type Props = {
   fileName: string;
@@ -13,7 +14,10 @@ export function Tabs({ fileName, activeTab }: Props) {
     <>
       <FileNavigation fileName={fileName} activeTab={activeTab} />
 
-      <TotalAmount fileName={fileName} />
+      <div className="flex items-center justify-between">
+        <TotalAmount fileName={fileName} />
+        <CsvExportButton fileName={fileName} />
+      </div>
 
       <div role="tablist" className="tabs tabs-border">
         <Link

--- a/src/utils/downloadCsv.test.ts
+++ b/src/utils/downloadCsv.test.ts
@@ -1,0 +1,66 @@
+import { expect, test, vi, beforeEach } from "vitest";
+import { sanitizeCell, downloadCsv } from "./downloadCsv";
+
+// sanitizeCell
+
+test("通常の文字列はダブルクォートで囲まれる", () => {
+  expect(sanitizeCell("スターバックス")).toBe('"スターバックス"');
+});
+
+test('ダブルクォートを含む値は "" にエスケープされる', () => {
+  expect(sanitizeCell('彼は"天才"だ')).toBe('"彼は""天才""だ"');
+});
+
+test("= で始まる値に ' を前置する（CSV Injection 対策）", () => {
+  expect(sanitizeCell("=SUM(A1:A10)")).toBe('"\'=SUM(A1:A10)"');
+});
+
+test("+ で始まる値に ' を前置する", () => {
+  expect(sanitizeCell("+123")).toBe(`"'+123"`);
+});
+
+test("- で始まる値に ' を前置する", () => {
+  expect(sanitizeCell("-123")).toBe(`"'-123"`);
+});
+
+test("@ で始まる値に ' を前置する", () => {
+  expect(sanitizeCell("@foo")).toBe('"\'@foo"');
+});
+
+test("危険文字が先頭以外にある場合はそのまま", () => {
+  expect(sanitizeCell("foo=bar")).toBe('"foo=bar"');
+});
+
+// downloadCsv
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    createObjectURL: vi.fn(() => "blob:fake"),
+    revokeObjectURL: vi.fn(),
+  });
+
+  const fakeLink = {
+    href: "",
+    download: "",
+    click: vi.fn(),
+  };
+  vi.spyOn(document, "createElement").mockReturnValue(
+    fakeLink as unknown as HTMLElement,
+  );
+});
+
+test("downloadCsv: ヘッダー行とデータ行を含むファイルをダウンロードする", () => {
+  const clickSpy = vi.fn();
+  const fakeLink = { href: "", download: "", click: clickSpy };
+  vi.spyOn(document, "createElement").mockReturnValue(
+    fakeLink as unknown as HTMLElement,
+  );
+
+  downloadCsv("test.csv", [
+    ["日付", "金額", "カテゴリ", "説明"],
+    ["2024-01-01", "1000", "食費", "スタバ"],
+  ]);
+
+  expect(fakeLink.download).toBe("test.csv");
+  expect(clickSpy).toHaveBeenCalledOnce();
+});

--- a/src/utils/downloadCsv.ts
+++ b/src/utils/downloadCsv.ts
@@ -1,4 +1,4 @@
-function sanitizeCell(cell: string): string {
+export function sanitizeCell(cell: string): string {
   const escaped = cell.replace(/"/g, '""');
   // CSV injection 対策: =,+,-,@ で始まる値の前に ' を付与
   if (/^[=+\-@]/.test(escaped)) {

--- a/src/utils/downloadCsv.ts
+++ b/src/utils/downloadCsv.ts
@@ -1,6 +1,15 @@
+function sanitizeCell(cell: string): string {
+  const escaped = cell.replace(/"/g, '""');
+  // CSV injection 対策: =,+,-,@ で始まる値の前に ' を付与
+  if (/^[=+\-@]/.test(escaped)) {
+    return `"'${escaped}"`;
+  }
+  return `"${escaped}"`;
+}
+
 export function downloadCsv(filename: string, rows: string[][]): void {
   const csvContent = rows
-    .map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(","))
+    .map((row) => row.map(sanitizeCell).join(","))
     .join("\n");
 
   const blob = new Blob(["﻿" + csvContent], {

--- a/src/utils/downloadCsv.ts
+++ b/src/utils/downloadCsv.ts
@@ -1,0 +1,15 @@
+export function downloadCsv(filename: string, rows: string[][]): void {
+  const csvContent = rows
+    .map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(","))
+    .join("\n");
+
+  const blob = new Blob(["﻿" + csvContent], {
+    type: "text/csv;charset=utf-8;",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
close #133

## 目的

支払い詳細画面（`/payments/:fileName`）で、その月の支払いデータをCSVとしてダウンロードできるようにする。

## 変更内容

- `src/utils/downloadCsv.ts` — UTF-8 BOM付きCSVをクライアントサイドで生成・ダウンロードするユーティリティを追加。`=`,`+`,`-`,`@`で始まるセルには`'`を前置してCSV Injectionを防止。
- `src/pages/DetailPage/components/CsvExportButton.tsx` — `usePaymentsByCategory`でカテゴリ付き支払いデータを取得し、日付・金額・カテゴリ・説明の4列でCSVを出力するボタンコンポーネントを追加。
- `src/pages/DetailPage/DetailPage.tsx` — `CsvExportButton`を`flex justify-end`の独立divで配置。

## ローカル検証手順

1. `npm run dev` でアプリを起動
2. CSVファイルをインポートして支払い詳細画面を開く
3. 「CSVエクスポート」ボタンを押下し、CSVファイルがダウンロードされることを確認
4. ダウンロードされたファイルをExcelで開き、文字化けなし・ヘッダー行あり・カテゴリ列に値が入っていることを確認