### PR TITLE
同名ファイル登録時に上書き確認ダイアログを表示する

### DIFF
--- a/src/data/payments/import/addPayments.test.ts
+++ b/src/data/payments/import/addPayments.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, test, vi } from "vitest";
 import {
   addPayments,
+  upsertPayments,
   AddPaymentsConstraintError,
   AddPaymentsInvalidFileError,
 } from "./addPayments";
@@ -10,11 +11,20 @@ import {
 } from "./convertFileToCsvData";
 import {
   createPayments,
+  upsertPayments as upsertPaymentsCore,
   CreatePaymentsConstraintError,
 } from "./createPayments";
 import { convertCsvDataToPaymentData } from "./convertCsvDataToPaymentData";
 
-vi.mock("./createPayments");
+// createPayments と upsertPayments のみをモックし、クラスは実実装を使う
+vi.mock("./createPayments", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./createPayments")>();
+  return {
+    ...actual,
+    createPayments: vi.fn(),
+    upsertPayments: vi.fn(),
+  };
+});
 vi.mock("./convertFileToCsvData");
 vi.mock("./convertCsvDataToPaymentData");
 
@@ -49,6 +59,7 @@ beforeEach(() => {
   });
 
   vi.mocked(createPayments).mockResolvedValue(undefined);
+  vi.mocked(upsertPaymentsCore).mockResolvedValue(undefined);
 });
 
 test("正常系: データ登録", async () => {
@@ -93,10 +104,29 @@ test("異常系: IndexedDBへの登録でエラーが発生した場合(重複)"
   );
 });
 
+test("異常系: IndexedDBへの登録でエラーが発生した場合(重複)、conflictingFileNamesが伝播する", async () => {
+  vi.mocked(createPayments).mockRejectedValue(
+    new CreatePaymentsConstraintError("dummy_message", {
+      cause: undefined,
+      conflictingFileNames: ["test1.csv"],
+    }),
+  );
+
+  const result = addPayments(dummyFiles);
+  await expect(result).rejects.toMatchObject({
+    conflictingFileNames: ["test1.csv"],
+  });
+});
+
 test("異常系: IndexedDBへの登録でエラーが発生した場合", async () => {
   vi.mocked(createPayments).mockRejectedValue(new Error("dummy_message"));
 
   await expect(addPayments(dummyFiles)).rejects.toThrow(
     "不明なエラーが発生しました。",
   );
+});
+
+test("upsertPayments: 正常系", async () => {
+  await expect(upsertPayments(dummyFiles)).resolves.toBeUndefined();
+  expect(upsertPaymentsCore).toHaveBeenCalled();
 });

--- a/src/data/payments/import/addPayments.ts
+++ b/src/data/payments/import/addPayments.ts
@@ -1,6 +1,7 @@
 import { convertCsvDataToPaymentData } from "./convertCsvDataToPaymentData";
 import {
   createPayments,
+  upsertPayments as upsertPaymentsCore,
   CreatePaymentsConstraintError,
 } from "./createPayments";
 import {
@@ -9,7 +10,9 @@ import {
 } from "./convertFileToCsvData";
 import type { Payment } from "./paymentSchema";
 
-export async function addPayments(files: File[]): Promise<void> {
+async function buildPaymentData(
+  files: File[],
+): Promise<{ fileName: string; payments: Payment[] }[]> {
   // Step 1: CSVファイルをパース
   let csvDataList: { fileName: string; csvData: unknown[] }[];
   try {
@@ -60,12 +63,14 @@ export async function addPayments(files: File[]): Promise<void> {
     }),
   }));
 
-  const filteredPaymentData = sortedPaymentData.map(
-    ({ fileName, payments }) => ({
-      fileName,
-      payments: payments.filter((payment) => payment.name.length > 0),
-    }),
-  );
+  return sortedPaymentData.map(({ fileName, payments }) => ({
+    fileName,
+    payments: payments.filter((payment) => payment.name.length > 0),
+  }));
+}
+
+export async function addPayments(files: File[]): Promise<void> {
+  const filteredPaymentData = await buildPaymentData(files);
 
   // Step 4: DBに保存
   try {
@@ -73,13 +78,18 @@ export async function addPayments(files: File[]): Promise<void> {
   } catch (err) {
     console.error(err);
     if (err instanceof CreatePaymentsConstraintError) {
-      throw new AddPaymentsConstraintError(
-        "ファイルは既に登録されています。別のファイルを選択してください。",
-        { cause: err },
-      );
+      throw new AddPaymentsConstraintError("ファイルは既に登録されています。", {
+        cause: err,
+        conflictingFileNames: err.conflictingFileNames,
+      });
     }
     throw new Error("不明なエラーが発生しました。", { cause: err });
   }
+}
+
+export async function upsertPayments(files: File[]): Promise<void> {
+  const filteredPaymentData = await buildPaymentData(files);
+  await upsertPaymentsCore(filteredPaymentData);
 }
 
 export class AddPaymentsInvalidFileError extends Error {
@@ -92,8 +102,13 @@ export class AddPaymentsInvalidFileError extends Error {
 
 export class AddPaymentsConstraintError extends Error {
   override readonly name = "AddPaymentsConstraintError" as const;
-  constructor(message: string, options?: { cause: unknown }) {
+  readonly conflictingFileNames: string[];
+  constructor(
+    message: string,
+    options?: { cause: unknown; conflictingFileNames?: string[] },
+  ) {
     super(message, options);
     this.cause = options?.cause;
+    this.conflictingFileNames = options?.conflictingFileNames ?? [];
   }
 }

--- a/src/data/payments/import/createPayments.test.ts
+++ b/src/data/payments/import/createPayments.test.ts
@@ -11,6 +11,15 @@ vi.mock("../../db", () => ({
       bulkAdd: vi.fn(),
       bulkPut: vi.fn(),
     },
+    transaction: vi.fn(
+      async (
+        _mode: string,
+        _tables: unknown,
+        callback: () => Promise<void>,
+      ) => {
+        return await callback();
+      },
+    ),
   },
 }));
 

--- a/src/data/payments/import/createPayments.test.ts
+++ b/src/data/payments/import/createPayments.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, test, vi } from "vitest";
 import {
   createPayments,
+  upsertPayments,
   CreatePaymentsConstraintError,
 } from "./createPayments";
 
@@ -8,6 +9,7 @@ vi.mock("../../db", () => ({
   db: {
     paymentFiles: {
       bulkAdd: vi.fn(),
+      bulkPut: vi.fn(),
     },
   },
 }));
@@ -57,9 +59,29 @@ test("異常系: 重複ファイルの場合、CreatePaymentsConstraintErrorをt
         payments: [{ date: "2023-01-01", name: "食費", price: 1000, count: 1 }],
       },
     ]),
-  ).rejects.toThrow(
-    "ファイルは既に登録されています。別のファイルを選択してください。",
-  );
+  ).rejects.toThrow("ファイルは既に登録されています。");
+});
+
+test("異常系: BulkErrorの場合、conflictingFileNamesにfailedKeysが含まれる", async () => {
+  const constraintError = Object.assign(new Error("BulkError"), {
+    name: "BulkError",
+    failures: [
+      Object.assign(new Error("ConstraintError"), { name: "ConstraintError" }),
+    ],
+    failedKeys: ["duplicate.csv"],
+  });
+  vi.mocked(db.paymentFiles.bulkAdd).mockRejectedValue(constraintError);
+
+  const result = createPayments([
+    {
+      fileName: "duplicate.csv",
+      payments: [{ date: "2023-01-01", name: "食費", price: 1000, count: 1 }],
+    },
+  ]);
+
+  await expect(result).rejects.toMatchObject({
+    conflictingFileNames: ["duplicate.csv"],
+  });
 });
 
 test("異常系: その他のエラーの場合、CreatePaymentsUnknownErrorをthrowする", async () => {
@@ -75,4 +97,22 @@ test("異常系: その他のエラーの場合、CreatePaymentsUnknownErrorをt
       },
     ]),
   ).rejects.toThrow("不明なエラーが発生しました。");
+});
+
+test("upsertPayments: bulkPutを呼び出す", async () => {
+  vi.mocked(db.paymentFiles.bulkPut).mockResolvedValue([] as never);
+
+  await upsertPayments([
+    {
+      fileName: "test.csv",
+      payments: [{ date: "2023-01-01", name: "食費", price: 1000, count: 1 }],
+    },
+  ]);
+
+  expect(db.paymentFiles.bulkPut).toHaveBeenCalledWith([
+    {
+      fileName: "test.csv",
+      payments: [{ date: "2023-01-01", name: "食費", price: 1000, count: 1 }],
+    },
+  ]);
 });

--- a/src/data/payments/import/createPayments.ts
+++ b/src/data/payments/import/createPayments.ts
@@ -5,12 +5,15 @@ type Input = { fileName: string; payments: Payment[] }[];
 
 export async function createPayments(items: Input): Promise<void> {
   try {
-    await db.paymentFiles.bulkAdd(
-      items.map((item) => ({
-        fileName: item.fileName,
-        payments: item.payments,
-      })),
-    );
+    // トランザクションで包むことで、一部が重複した場合に成功分もロールバックする
+    await db.transaction("rw", db.paymentFiles, async () => {
+      await db.paymentFiles.bulkAdd(
+        items.map((item) => ({
+          fileName: item.fileName,
+          payments: item.payments,
+        })),
+      );
+    });
   } catch (err) {
     if (isDexieConstraintError(err)) {
       const conflictingFileNames = extractConflictingFileNames(err, items);

--- a/src/data/payments/import/createPayments.ts
+++ b/src/data/payments/import/createPayments.ts
@@ -13,14 +13,24 @@ export async function createPayments(items: Input): Promise<void> {
     );
   } catch (err) {
     if (isDexieConstraintError(err)) {
+      const conflictingFileNames = extractConflictingFileNames(err, items);
       throw new CreatePaymentsConstraintError(
-        `ファイルは既に登録されています。別のファイルを選択してください。`,
-        { cause: err },
+        "ファイルは既に登録されています。",
+        { cause: err, conflictingFileNames },
       );
     }
 
     throw new Error("不明なエラーが発生しました。", { cause: err });
   }
+}
+
+export async function upsertPayments(items: Input): Promise<void> {
+  await db.paymentFiles.bulkPut(
+    items.map((item) => ({
+      fileName: item.fileName,
+      payments: item.payments,
+    })),
+  );
 }
 
 function isDexieConstraintError(error: unknown): boolean {
@@ -42,10 +52,27 @@ function isDexieConstraintError(error: unknown): boolean {
   return false;
 }
 
+function extractConflictingFileNames(error: unknown, items: Input): string[] {
+  if (!(error instanceof Error)) return [];
+
+  if (error.name === "BulkError" && "failedKeys" in error) {
+    const failedKeys = (error as { failedKeys: unknown[] }).failedKeys;
+    return failedKeys.filter((k): k is string => typeof k === "string");
+  }
+
+  // Direct ConstraintError: single item case
+  return items.map((item) => item.fileName);
+}
+
 export class CreatePaymentsConstraintError extends Error {
   override readonly name = "CreatePaymentsConstraintError" as const;
-  constructor(message: string, options?: { cause: unknown }) {
+  readonly conflictingFileNames: string[];
+  constructor(
+    message: string,
+    options?: { cause: unknown; conflictingFileNames?: string[] },
+  ) {
     super(message, options);
     this.cause = options?.cause;
+    this.conflictingFileNames = options?.conflictingFileNames ?? [];
   }
 }

--- a/src/data/payments/index.ts
+++ b/src/data/payments/index.ts
@@ -4,6 +4,7 @@ export { usePaymentsByCategory } from "./usePaymentsByCategory";
 export { deletePaymentFile } from "./deletePaymentFile";
 export {
   addPayments,
+  upsertPayments,
   AddPaymentsConstraintError,
   AddPaymentsInvalidFileError,
 } from "./import/addPayments";

--- a/src/pages/RootPage/RootPage.test.tsx
+++ b/src/pages/RootPage/RootPage.test.tsx
@@ -134,8 +134,9 @@ describe("RootPage", () => {
       });
     });
 
-    test("異常系: 同じファイル名で2回アップロードするとAddPaymentsConstraintErrorが表示される", async () => {
+    test("異常系: 同じファイル名で2回アップロードすると上書き確認ダイアログが表示される", async () => {
       const user = userEvent.setup();
+      mockConfirm.mockReturnValue(false);
       renderWithRouter({ component: <RootPage /> });
 
       const file1 = createTestCsvFile("duplicate.csv", [
@@ -162,9 +163,51 @@ describe("RootPage", () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        expect(mockAlert).toHaveBeenCalledWith(
-          "ファイルは既に登録されています。別のファイルを選択してください。",
+        expect(mockConfirm).toHaveBeenCalledWith(
+          "duplicate.csv はすでに登録されています。上書きしますか？",
         );
+      });
+    });
+
+    test("正常系: 上書き確認ダイアログで「上書きする」を選択するとデータが更新される", async () => {
+      const user = userEvent.setup();
+      renderWithRouter({ component: <RootPage /> });
+
+      const file1 = createTestCsvFile("duplicate.csv", [
+        { date: "2024/01/01", name: "食費", price: 1000 },
+      ]);
+
+      const fileInput = await getFileInput();
+      await user.upload(fileInput, file1);
+
+      const submitButton = screen.getByRole("button", { name: "登録" });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("duplicate.csv")).toBeInTheDocument();
+      });
+
+      // Second upload with same file name - confirm overwrite
+      mockConfirm.mockReturnValue(true);
+
+      const file2 = createTestCsvFile("duplicate.csv", [
+        { date: "2024/02/01", name: "交通費", price: 500 },
+      ]);
+
+      await user.upload(fileInput, file2);
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockConfirm).toHaveBeenCalledWith(
+          "duplicate.csv はすでに登録されています。上書きしますか？",
+        );
+      });
+
+      // Verify data is updated
+      await waitFor(async () => {
+        const storedFile = await db.paymentFiles.get("duplicate.csv");
+        expect(storedFile?.payments).toHaveLength(1);
+        expect(storedFile?.payments[0].name).toBe("交通費");
       });
     });
   });

--- a/src/pages/RootPage/RootPage.tsx
+++ b/src/pages/RootPage/RootPage.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import {
   addPayments,
+  upsertPayments,
   AddPaymentsConstraintError,
   AddPaymentsInvalidFileError,
   usePaymentsFiles,
@@ -44,9 +45,23 @@ export function RootPage() {
       }
 
       if (err instanceof AddPaymentsConstraintError) {
-        alert(
-          "ファイルは既に登録されています。別のファイルを選択してください。",
-        );
+        const names = err.conflictingFileNames.join("、");
+        const message =
+          names.length > 0
+            ? `${names} はすでに登録されています。上書きしますか？`
+            : "選択したファイルはすでに登録されています。上書きしますか？";
+        if (!confirm(message)) {
+          return;
+        }
+        try {
+          await upsertPayments(selectedFiles);
+          setSelectedFiles(undefined);
+          if (fileInputRef.current) {
+            (fileInputRef.current as HTMLInputElement).value = "";
+          }
+        } catch {
+          alert("ファイルの上書きに失敗しました。");
+        }
         return;
       }
 


### PR DESCRIPTION
close #143

## 概要

同名 CSV ファイルを登録しようとした際、従来はアラートで処理をブロックするだけだったが、上書き可否を確認するダイアログを表示してユーザーが選択できるように変更した。

## 変更内容

- **`createPayments.ts`**: `upsertPayments()`（`bulkPut` を使用）を追加。`CreatePaymentsConstraintError` に `conflictingFileNames` プロパティを追加し、重複したファイル名を格納する。また `bulkAdd()` を `db.transaction("rw")` で囲み、複数ファイル一括登録で一部が重複する場合にバッチ全体をロールバックする（新規ファイルが意図せず追加されるのを防ぐ）。
- **`addPayments.ts`**: `buildPaymentData()` ヘルパーを抽出して `addPayments` / `upsertPayments` で共用。`AddPaymentsConstraintError` に `conflictingFileNames` を追加し伝播させる。
- **`RootPage.tsx`**: `AddPaymentsConstraintError` をキャッチした際に `window.confirm()` で上書き確認を取り、OK の場合は `upsertPayments()` で既存データを置き換える。

## 動作確認手順

1. `npm run dev` でアプリを起動
2. 任意の CSV ファイルを登録する
3. 同じファイルを再度選択して「登録」ボタンを押す
4. 「〇〇.csv はすでに登録されています。上書きしますか？」ダイアログが表示されることを確認
5. 「OK」を押すと既存データが新しいファイルで置き換えられることを確認
6. 「キャンセル」を押すと何も変わらないことを確認