### PR TITLE
feat: エクスポートCSVをファイル登録フォームから再インポートできるようにする

### DIFF
--- a/src/data/payments/import/convertFileToCsvData.test.ts
+++ b/src/data/payments/import/convertFileToCsvData.test.ts
@@ -131,3 +131,31 @@ test("正常系: 確定前フォーマット（13カラム）のCSVがパース�
     },
   ]);
 });
+
+test("正常系: エクスポートフォーマット（ヘッダー行あり4カラム）のCSVがパースされる", async () => {
+  const mockCsvData = [
+    {
+      date: "2025/12/31",
+      price: "6350",
+      category: "食費",
+      name: "バロー",
+    },
+  ];
+  const exportFormatCsv =
+    "日付,金額,カテゴリ,説明\n2025/12/31,6350,食費,バロー";
+  vi.mocked(Encoding.convert).mockReturnValue(exportFormatCsv as never);
+  vi.mocked(parse).mockReturnValue(mockCsvData as never);
+
+  const file = createMockFile(exportFormatCsv, "test.csv");
+  const result = await convertFileToCsvData({ file });
+
+  // エクスポートフォーマットはcount=1で正規化され、説明がnameになる
+  expect(result.csvData).toEqual([
+    {
+      date: "2025/12/31",
+      name: "バロー",
+      price: "6350",
+      count: "1",
+    },
+  ]);
+});

--- a/src/data/payments/import/convertFileToCsvData.test.ts
+++ b/src/data/payments/import/convertFileToCsvData.test.ts
@@ -132,7 +132,7 @@ test("正常系: 確定前フォーマット（13カラム）のCSVがパース�
   ]);
 });
 
-test("正常系: エクスポートフォーマット（ヘッダー行あり4カラム）のCSVがパースされる", async () => {
+test("正常系: エクスポートフォーマット（BOM付き・クォート・ヘッダー行あり）のCSVがパースされる", async () => {
   const mockCsvData = [
     {
       date: "2025/12/31",
@@ -141,8 +141,9 @@ test("正常系: エクスポートフォーマット（ヘッダー行あり4�
       name: "バロー",
     },
   ];
+  // 実際のエクスポートCSVはBOM付きで全セルがダブルクォートされる
   const exportFormatCsv =
-    "日付,金額,カテゴリ,説明\n2025/12/31,6350,食費,バロー";
+    '﻿"日付","金額","カテゴリ","説明"\n"2025/12/31","6350","食費","バロー"';
   vi.mocked(Encoding.convert).mockReturnValue(exportFormatCsv as never);
   vi.mocked(parse).mockReturnValue(mockCsvData as never);
 

--- a/src/data/payments/import/convertFileToCsvData.ts
+++ b/src/data/payments/import/convertFileToCsvData.ts
@@ -91,14 +91,26 @@ export async function convertFileToCsvData(input: Input): Promise<Output> {
   try {
     const arrayBuffer = await input.file.arrayBuffer();
     const uint8 = new Uint8Array(arrayBuffer);
-    const paymentTextArray = Encoding.convert(uint8, {
-      from: "SJIS",
-      to: "UTF8",
-    });
-    const paymentText =
-      typeof paymentTextArray === "string"
-        ? paymentTextArray
-        : String.fromCharCode(...paymentTextArray);
+
+    // UTF-8 BOM (0xEF 0xBB 0xBF) があればそのままデコード、なければ SJIS→UTF8 変換
+    const isUtf8WithBom =
+      uint8.length >= 3 &&
+      uint8[0] === 0xef &&
+      uint8[1] === 0xbb &&
+      uint8[2] === 0xbf;
+
+    let paymentTextArray: string | number[];
+    let paymentText: string;
+    if (isUtf8WithBom) {
+      paymentText = new TextDecoder("utf-8").decode(uint8.slice(3));
+      paymentTextArray = paymentText;
+    } else {
+      paymentTextArray = Encoding.convert(uint8, { from: "SJIS", to: "UTF8" });
+      paymentText =
+        typeof paymentTextArray === "string"
+          ? paymentTextArray
+          : String.fromCharCode(...paymentTextArray);
+    }
 
     const { columns, fromLine } = detectFormat(paymentText);
 

--- a/src/data/payments/import/convertFileToCsvData.ts
+++ b/src/data/payments/import/convertFileToCsvData.ts
@@ -38,11 +38,16 @@ const EXPORT_FORMAT_COLUMNS = ["date", "price", "category", "name"];
 type FormatConfig = { columns: string[]; fromLine: number };
 
 function detectFormat(text: string): FormatConfig {
-  const lines = text.split("\n").filter((line) => line.trim().length > 0);
+  const textWithoutBom = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+  const lines = textWithoutBom
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
   if (lines.length === 0) {
     return { columns: CONFIRMED_FORMAT_COLUMNS, fromLine: 1 };
   }
-  if (lines[0].startsWith("日付,金額,カテゴリ,説明")) {
+  // ダブルクォートを除去してヘッダー行を比較（エクスポートCSVは全セルクォート済み）
+  const firstLineUnquoted = lines[0].replace(/"/g, "");
+  if (firstLineUnquoted.startsWith("日付,金額,カテゴリ,説明")) {
     return { columns: EXPORT_FORMAT_COLUMNS, fromLine: 2 };
   }
   const firstLineColumnCount = lines[0].split(",").length;

--- a/src/data/payments/import/convertFileToCsvData.ts
+++ b/src/data/payments/import/convertFileToCsvData.ts
@@ -32,15 +32,27 @@ const PENDING_FORMAT_COLUMNS = [
   "exchangeDate",
 ];
 
-function detectFormat(text: string): string[] {
+// エクスポートフォーマット（4カラム、ヘッダー行あり）: 日付, 金額, カテゴリ, 説明
+const EXPORT_FORMAT_COLUMNS = ["date", "price", "category", "name"];
+
+type FormatConfig = { columns: string[]; fromLine: number };
+
+function detectFormat(text: string): FormatConfig {
   const lines = text.split("\n").filter((line) => line.trim().length > 0);
   if (lines.length === 0) {
-    return CONFIRMED_FORMAT_COLUMNS;
+    return { columns: CONFIRMED_FORMAT_COLUMNS, fromLine: 1 };
+  }
+  if (lines[0].startsWith("日付,金額,カテゴリ,説明")) {
+    return { columns: EXPORT_FORMAT_COLUMNS, fromLine: 2 };
   }
   const firstLineColumnCount = lines[0].split(",").length;
-  return firstLineColumnCount >= 13
-    ? PENDING_FORMAT_COLUMNS
-    : CONFIRMED_FORMAT_COLUMNS;
+  return {
+    columns:
+      firstLineColumnCount >= 13
+        ? PENDING_FORMAT_COLUMNS
+        : CONFIRMED_FORMAT_COLUMNS,
+    fromLine: 1,
+  };
 }
 
 function normalizeToCommonFormat(
@@ -49,6 +61,15 @@ function normalizeToCommonFormat(
 ): unknown[] {
   // 確定前フォーマットの場合、countをデフォルト値1に設定
   if (columns === PENDING_FORMAT_COLUMNS) {
+    return csvData.map((row) => ({
+      date: row.date,
+      name: row.name,
+      price: row.price,
+      count: "1",
+    }));
+  }
+  // エクスポートフォーマットの場合、説明をname、countを1に設定
+  if (columns === EXPORT_FORMAT_COLUMNS) {
     return csvData.map((row) => ({
       date: row.date,
       name: row.name,
@@ -74,12 +95,13 @@ export async function convertFileToCsvData(input: Input): Promise<Output> {
         ? paymentTextArray
         : String.fromCharCode(...paymentTextArray);
 
-    const columns = detectFormat(paymentText);
+    const { columns, fromLine } = detectFormat(paymentText);
 
     const rawCsvData: Record<string, string>[] = parse(paymentTextArray, {
       columns,
       skip_empty_lines: true,
       skipRecordsWithError: true,
+      from_line: fromLine,
     });
 
     csvData = normalizeToCommonFormat(rawCsvData, columns);


### PR DESCRIPTION
close #145

## 概要

詳細ページの「CSVエクスポート」で出力したCSVファイルを、トップページのファイル登録フォームから登録できるようにする。

## 変更内容

- `src/data/payments/import/convertFileToCsvData.ts`
  - `EXPORT_FORMAT_COLUMNS` 定数を追加（エクスポートフォーマット: `date, price, category, name`）
  - `detectFormat` をリファクタリングして `FormatConfig`（`columns` + `fromLine`）を返すよう変更
  - エクスポートCSVのヘッダー行（`日付,金額,カテゴリ,説明`）を検出するロジックを追加
    - BOM（`﻿`）対応: `charCodeAt(0)` でBOMを除去してから判定
    - 全セルクォート対応: ダブルクォートを除去してからヘッダーを比較
  - `normalizeToCommonFormat` でエクスポートフォーマットを `{ date, name, price, count: "1" }` に変換
  - `from_line: fromLine` オプションを追加し、ヘッダー行をスキップ

- `src/data/payments/import/convertFileToCsvData.test.ts`
  - エクスポートフォーマット（BOM付き・クォート・ヘッダー行あり）のインポートテストを追加

## ローカル検証手順

1. `npm run dev` でアプリ起動
2. 詳細ページから「CSVエクスポート」でCSVファイルをダウンロード
3. ダウンロードしたCSVをトップページのファイル登録フォームにアップロード
4. エラーなく登録でき、日付・金額・説明が正しく表示されることを確認
5. 既存の銀行CSV（確定後・確定前フォーマット）の登録が引き続き正常動作することを確認